### PR TITLE
Fix windows line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-/data/* eol=lf
+* eol=lf
 reports/* linguist-generated
 target/criterion/* linguist-generated
 target/docs/* linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/data/* eol=lf
 reports/* linguist-generated
 target/criterion/* linguist-generated
 target/docs/* linguist-documentation

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,8 +22,8 @@ jobs:
           - nightly
         os: 
           - ubuntu-latest
+          - windows-latest
           #- macos-latest
-          #- windows-latest
         target_feature:
           - avx2
     steps:


### PR DESCRIPTION
Force all json files in `data` to have LF line endings.

Fixes #15 