### PR TITLE
fix: remove SHA from --version on crates.io

### DIFF
--- a/crates/rsonpath/src/version.rs
+++ b/crates/rsonpath/src/version.rs
@@ -15,7 +15,9 @@ pub fn get_long_version() -> &'static str {
 
         res += "\n";
         for (k, v) in details {
-            res += &format!("\n{: <16} {}", k, v);
+            if v != "VERGEN_IDEMPOTENT_OUTPUT" {
+                res += &format!("\n{: <16} {}", k, v);
+            }
         }
 
         res


### PR DESCRIPTION
## Issue

Minor. The Commit SHA part was incorrect, and there seems to be no way to get it when the crate is in registry.

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.