### PR TITLE
feat: consistent index result output

### DIFF
--- a/crates/rsonpath-lib/src/engine/error.rs
+++ b/crates/rsonpath-lib/src/engine/error.rs
@@ -29,6 +29,9 @@ pub enum EngineError {
     /// closing characters.
     #[error("Malformed input JSON; end of input was reached, but unmatched opening characters remained.")]
     MissingClosingCharacter(),
+    /// The engine found a query match, but no value associated with it.
+    #[error("Malformed input JSON; a query match was found, but there was no associated value")]
+    MissingItem(),
     /// An error occurred when trying to parse a member name terminated by a particular colon character.
     /// The inner [`usize`] value should be set to the byte index of the colon.
     #[error(

--- a/crates/rsonpath-lib/src/engine/recursive.rs
+++ b/crates/rsonpath-lib/src/engine/recursive.rs
@@ -1,28 +1,28 @@
 //! Reference implementation of a JSONPath query engine with recursive descent.
 #[cfg(feature = "head-skip")]
 use super::head_skipping::{CanHeadSkip, HeadSkip};
-use crate::classification::quotes::QuoteClassifiedIterator;
-use crate::classification::structural::classify_structural_characters;
-use crate::classification::structural::BracketType;
-use crate::classification::structural::Structural;
-use crate::classification::structural::StructuralIterator;
 #[cfg(feature = "head-skip")]
 use crate::classification::ResumeClassifierState;
-use crate::debug;
-use crate::engine::error::EngineError;
 #[cfg(feature = "tail-skip")]
 use crate::engine::tail_skipping::TailSkip;
-use crate::engine::{Compiler, Engine};
 #[cfg(feature = "head-skip")]
 use crate::error::InternalRsonpathError;
-use crate::input::Input;
-use crate::query::automaton::{Automaton, State, TransitionLabel};
-use crate::query::error::{ArrayIndexError, CompilerError};
-use crate::query::{JsonPathQuery, JsonString, NonNegativeArrayIndex};
-use crate::result::{QueryResult, QueryResultBuilder};
-use crate::FallibleIterator;
-use crate::BLOCK_SIZE;
-use crate::{classification::quotes::classify_quoted_sequences, result::NodeTypeHint};
+use crate::{
+    classification::{
+        quotes::{classify_quoted_sequences, QuoteClassifiedIterator},
+        structural::{classify_structural_characters, BracketType, Structural, StructuralIterator},
+    },
+    debug,
+    engine::{error::EngineError, Compiler, Engine},
+    input::Input,
+    query::{
+        automaton::{Automaton, State, TransitionLabel},
+        error::{ArrayIndexError, CompilerError},
+        JsonPathQuery, JsonString, NonNegativeArrayIndex,
+    },
+    result::{NodeTypeHint, QueryResult, QueryResultBuilder},
+    FallibleIterator, BLOCK_SIZE,
+};
 
 /// Recursive implementation of the JSONPath query engine.
 pub struct RecursiveEngine<'q> {

--- a/crates/rsonpath-lib/src/engine/recursive.rs
+++ b/crates/rsonpath-lib/src/engine/recursive.rs
@@ -1,7 +1,6 @@
 //! Reference implementation of a JSONPath query engine with recursive descent.
 #[cfg(feature = "head-skip")]
 use super::head_skipping::{CanHeadSkip, HeadSkip};
-use crate::classification::quotes::classify_quoted_sequences;
 use crate::classification::quotes::QuoteClassifiedIterator;
 use crate::classification::structural::classify_structural_characters;
 use crate::classification::structural::BracketType;
@@ -20,9 +19,10 @@ use crate::input::Input;
 use crate::query::automaton::{Automaton, State, TransitionLabel};
 use crate::query::error::{ArrayIndexError, CompilerError};
 use crate::query::{JsonPathQuery, JsonString, NonNegativeArrayIndex};
-use crate::result::QueryResult;
+use crate::result::{QueryResult, QueryResultBuilder};
 use crate::FallibleIterator;
 use crate::BLOCK_SIZE;
+use crate::{classification::quotes::classify_quoted_sequences, result::NodeTypeHint};
 
 /// Recursive implementation of the JSONPath query engine.
 pub struct RecursiveEngine<'q> {
@@ -62,10 +62,10 @@ impl Engine for RecursiveEngine<'_> {
 
         match classifier.next()? {
             Some(Structural::Opening(b, idx)) => {
-                let mut result = R::default();
+                let mut result = R::Builder::new(input);
                 let mut execution_ctx = ExecutionContext::new(&self.automaton, input);
                 execution_ctx.run(&mut classifier, self.automaton.initial_state(), idx, b, &mut result)?;
-                Ok(result)
+                Ok(result.finish())
             }
             _ => Ok(R::default()),
         }
@@ -75,13 +75,13 @@ impl Engine for RecursiveEngine<'_> {
 fn empty_query<R: QueryResult, I: Input>(input: &I) -> Result<R, EngineError> {
     let quote_classifier = classify_quoted_sequences(input);
     let mut block_event_source = classify_structural_characters(quote_classifier);
-    let mut result = R::default();
+    let mut result = R::Builder::new(input);
 
     if let Some(Structural::Opening(_, idx)) = block_event_source.next()? {
-        result.report(idx);
+        result.report(idx, crate::result::NodeTypeHint::AnyComplex)?;
     }
 
-    Ok(result)
+    Ok(result.finish())
 }
 
 struct ExecutionContext<'q, 'b, I: Input> {
@@ -108,17 +108,18 @@ impl<'q, 'b, I: Input> ExecutionContext<'q, 'b, I> {
     }
 
     #[cfg(feature = "head-skip")]
-    fn run<'r, Q, S, R>(
+    fn run<'r, Q, S, B, R>(
         &mut self,
         classifier: &mut Classifier!(),
         state: State,
         open_idx: usize,
         bracket_type: BracketType,
-        result: &'r mut R,
+        result: &'r mut B,
     ) -> Result<(), EngineError>
     where
         Q: QuoteClassifiedIterator<'b, I, BLOCK_SIZE>,
         S: StructuralIterator<'b, I, Q, BLOCK_SIZE>,
+        B: QueryResultBuilder<'b, I, R>,
         R: QueryResult,
     {
         let mb_head_skip = HeadSkip::new(self.bytes, self.automaton);
@@ -132,34 +133,36 @@ impl<'q, 'b, I: Input> ExecutionContext<'q, 'b, I> {
     }
 
     #[cfg(not(feature = "head-skip"))]
-    fn run<'r, Q, S, R>(
+    fn run<'r, Q, S, B, R>(
         &mut self,
         classifier: &mut Classifier!(),
         state: State,
         open_idx: usize,
         bracket_type: BracketType,
-        result: &'r mut R,
+        result: &'r mut B,
     ) -> Result<(), EngineError>
     where
         Q: QuoteClassifiedIterator<'b, I, BLOCK_SIZE>,
         S: StructuralIterator<'b, I, Q, BLOCK_SIZE>,
+        B: QueryResultBuilder<'b, I, R>,
         R: QueryResult,
     {
         self.run_on_subtree(classifier, state, open_idx, bracket_type, result)
             .map(|_| ())
     }
 
-    fn run_on_subtree<'r, Q, S, R>(
+    fn run_on_subtree<'r, Q, S, B, R>(
         &mut self,
         classifier: &mut Classifier!(),
         state: State,
         open_idx: usize,
         bracket_type: BracketType,
-        result: &'r mut R,
+        result: &'r mut B,
     ) -> Result<usize, EngineError>
     where
         Q: QuoteClassifiedIterator<'b, I, BLOCK_SIZE>,
         S: StructuralIterator<'b, I, Q, BLOCK_SIZE>,
+        B: QueryResultBuilder<'b, I, R>,
         R: QueryResult,
     {
         debug!("Run state {state}");
@@ -206,7 +209,10 @@ impl<'q, 'b, I: Input> ExecutionContext<'q, 'b, I> {
             if let Some(Structural::Closing(_, close_idx)) = next_event {
                 if let Some((next_idx, _)) = self.bytes.seek_non_whitespace_forward(open_idx + 1)? {
                     if next_idx < close_idx {
-                        result.report(next_idx);
+                        result.report(
+                            next_idx,
+                            NodeTypeHint::Atomic, /* since the next structural is the closing of the list */
+                        )?;
                     }
                 }
                 return Ok(close_idx);
@@ -214,7 +220,10 @@ impl<'q, 'b, I: Input> ExecutionContext<'q, 'b, I> {
 
             if matches!(next_event, Some(Structural::Comma(_))) {
                 debug!("Accepting first item in the list.");
-                result.report(open_idx + 1);
+                result.report(
+                    open_idx + 1,
+                    NodeTypeHint::Atomic, /* since the next structural is a ','*/
+                )?;
             }
         }
 
@@ -232,7 +241,7 @@ impl<'q, 'b, I: Input> ExecutionContext<'q, 'b, I> {
 
                     if !is_next_opening && is_list && is_fallback_accepting {
                         debug!("Accepting on comma.");
-                        result.report(idx);
+                        result.report(idx, NodeTypeHint::Atomic /* since is_next_opening is false */)?;
                     }
 
                     // Once we are in comma search, we have already considered the option that the first item in the list is a match.  Iterate on the remaining items.
@@ -248,7 +257,7 @@ impl<'q, 'b, I: Input> ExecutionContext<'q, 'b, I> {
 
                     if is_accepting_list_item && !is_next_opening && match_index {
                         debug!("Accepting on list item.");
-                        result.report(idx);
+                        result.report(idx, NodeTypeHint::Atomic /* since is_next_opening is false */)?;
                     }
                 }
                 Some(Structural::Colon(idx)) => {
@@ -267,7 +276,8 @@ impl<'q, 'b, I: Input> ExecutionContext<'q, 'b, I> {
                                     if self.automaton.is_accepting(target) && self.is_match(idx, member_name)? =>
                                 {
                                     debug!("Accept {idx}");
-                                    result.report(idx);
+                                    result
+                                        .report(idx, NodeTypeHint::Atomic /* since is_next_opening is false */)?;
                                     any_matched = true;
                                     break;
                                 }
@@ -277,7 +287,7 @@ impl<'q, 'b, I: Input> ExecutionContext<'q, 'b, I> {
                         let fallback_state = self.automaton[state].fallback_state();
                         if !any_matched && self.automaton.is_accepting(fallback_state) {
                             debug!("Value accepted by fallback.");
-                            result.report(idx);
+                            result.report(idx, NodeTypeHint::Atomic /* since is_next_opening is false */)?;
                         }
                         #[cfg(feature = "unique-members")]
                         {
@@ -312,7 +322,7 @@ impl<'q, 'b, I: Input> ExecutionContext<'q, 'b, I> {
                                         if self.automaton.is_accepting(target) {
                                             debug!("Accept Object Member {}", member_name.display());
                                             debug!("Accept {idx}");
-                                            result.report(colon_idx);
+                                            result.report(colon_idx, NodeTypeHint::Complex(b))?;
                                         }
                                         break;
                                     }
@@ -324,7 +334,7 @@ impl<'q, 'b, I: Input> ExecutionContext<'q, 'b, I> {
                                     if self.automaton.is_accepting(target) {
                                         debug!("Accept Array Index {i}");
                                         debug!("Accept {idx}");
-                                        result.report(idx);
+                                        result.report(idx, NodeTypeHint::Complex(b))?;
                                     }
                                     break;
                                 }
@@ -340,7 +350,7 @@ impl<'q, 'b, I: Input> ExecutionContext<'q, 'b, I> {
 
                             if self.automaton.is_accepting(fallback) {
                                 debug!("Accept {idx}");
-                                result.report(idx);
+                                result.report(idx, NodeTypeHint::Complex(b))?;
                             }
 
                             #[cfg(feature = "tail-skip")]
@@ -407,15 +417,16 @@ impl<'q, 'b, I: Input> ExecutionContext<'q, 'b, I> {
 
 #[cfg(feature = "head-skip")]
 impl<'q, 'b, I: Input> CanHeadSkip<'b, I, BLOCK_SIZE> for ExecutionContext<'q, 'b, I> {
-    fn run_on_subtree<'r, R, Q, S>(
+    fn run_on_subtree<'r, B, R, Q, S>(
         &mut self,
         next_event: Structural,
         state: State,
         structural_classifier: S,
-        result: &'r mut R,
+        result: &'r mut B,
     ) -> Result<ResumeClassifierState<'b, I, Q, BLOCK_SIZE>, EngineError>
     where
         Q: QuoteClassifiedIterator<'b, I, BLOCK_SIZE>,
+        B: QueryResultBuilder<'b, I, R>,
         R: QueryResult,
         S: StructuralIterator<'b, I, Q, BLOCK_SIZE>,
     {

--- a/crates/rsonpath-lib/src/input.rs
+++ b/crates/rsonpath-lib/src/input.rs
@@ -74,6 +74,24 @@ pub trait Input: Sized {
     #[must_use]
     fn seek_backward(&self, from: usize, needle: u8) -> Option<usize>;
 
+    /// Search for an occurrence of `needle` in the input,
+    /// starting from `from`` and looking back. Returns the index
+    /// of the first occurrence or `None` if the `needle` was not found.
+    ///
+    /// # Errors
+    /// This function can read more data from the input if no relevant characters are found
+    /// in the current buffer, which can fail.
+    fn seek_forward(&self, from: usize, needle: u8) -> Result<Option<usize>, InputError>;
+
+    /// Search for an occurrence of `needle_1` or `needle_2` in the input,
+    /// starting from `from`` and looking back. Returns the index
+    /// of the first occurrence or `None` if neither `needle_1` nor `needle_2` was found.
+    ///
+    /// # Errors
+    /// This function can read more data from the input if no relevant characters are found
+    /// in the current buffer, which can fail.
+    fn seek_forward_2(&self, from: usize, needle_1: u8, needle_2: u8) -> Result<Option<usize>, InputError>;
+
     /// Search for the first byte in the input that is not ASCII whitespace
     /// starting from `from`. Returns a pair: the index of first such byte,
     /// and the byte itself; or `None` if no non-whitespace characters
@@ -180,6 +198,46 @@ pub(super) mod in_slice {
                 return None;
             }
             idx -= 1;
+        }
+    }
+
+    #[inline]
+    pub(super) fn seek_forward(bytes: &[u8], from: usize, needle: u8) -> Option<usize> {
+        let mut idx = from;
+
+        if idx >= bytes.len() {
+            return None;
+        }
+
+        loop {
+            let b = bytes[idx];
+            if b == needle {
+                return Some(idx);
+            }
+            idx += 1;
+            if idx == bytes.len() {
+                return None;
+            }
+        }
+    }
+
+    #[inline]
+    pub(super) fn seek_forward_2(bytes: &[u8], from: usize, needle_1: u8, needle_2: u8) -> Option<usize> {
+        let mut idx = from;
+
+        if idx >= bytes.len() {
+            return None;
+        }
+
+        loop {
+            let b = bytes[idx];
+            if b == needle_1 || b == needle_2 {
+                return Some(idx);
+            }
+            idx += 1;
+            if idx == bytes.len() {
+                return None;
+            }
         }
     }
 
@@ -346,6 +404,107 @@ mod tests {
         }
     }
 
+    mod seek_froward {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn in_empty_slice_returns_none() {
+            let bytes = [];
+
+            let result = in_slice::seek_forward(&bytes, 0, 0);
+
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn seeking_from_needle_returns_that() {
+            let bytes = r#"{"seek": 42}"#.as_bytes();
+
+            let result = in_slice::seek_forward(bytes, 7, b':');
+
+            assert_eq!(result, Some(7));
+        }
+
+        #[test]
+        fn seeking_from_not_needle_returns_next_needle() {
+            let bytes = "seek: \t\n42}".as_bytes();
+
+            let result = in_slice::seek_forward(bytes, 5, b'2');
+
+            assert_eq!(result, Some(9));
+        }
+
+        #[test]
+        fn seeking_from_not_needle_when_there_is_no_needle_returns_none() {
+            let bytes = "seek: \t\n42}".as_bytes();
+
+            let result = in_slice::seek_forward(bytes, 5, b'3');
+
+            assert_eq!(result, None);
+        }
+    }
+
+    mod seek_forward_2 {
+
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn in_empty_slice_returns_none() {
+            let bytes = [];
+
+            let result = in_slice::seek_forward_2(&bytes, 0, 0, 1);
+
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn seeking_from_needle_1_returns_that() {
+            let bytes = r#"{"seek": 42}"#.as_bytes();
+
+            let result = in_slice::seek_forward_2(bytes, 7, b':', b'4');
+
+            assert_eq!(result, Some(7));
+        }
+
+        #[test]
+        fn seeking_from_needle_2_returns_that() {
+            let bytes = r#"{"seek": 42}"#.as_bytes();
+
+            let result = in_slice::seek_forward_2(bytes, 7, b'4', b':');
+
+            assert_eq!(result, Some(7));
+        }
+
+        #[test]
+        fn seeking_from_not_needle_when_next_is_needle_1_returns_that() {
+            let bytes = "seek: \t\n42}".as_bytes();
+
+            let result = in_slice::seek_forward_2(bytes, 5, b'4', b'2');
+
+            assert_eq!(result, Some(8));
+        }
+
+        #[test]
+        fn seeking_from_not_needle_when_next_is_needle_2_returns_that() {
+            let bytes = "seek: \t\n42}".as_bytes();
+
+            let result = in_slice::seek_forward_2(bytes, 5, b'2', b'4');
+
+            assert_eq!(result, Some(8));
+        }
+
+        #[test]
+        fn seeking_from_not_needle_when_there_is_no_needle_returns_none() {
+            let bytes = "seek: \t\n42}".as_bytes();
+
+            let result = in_slice::seek_forward_2(bytes, 5, b'3', b'0');
+
+            assert_eq!(result, None);
+        }
+    }
+
     mod seek_non_whitespace_forward {
         use super::*;
         use pretty_assertions::assert_eq;
@@ -375,6 +534,15 @@ mod tests {
             let result = in_slice::seek_non_whitespace_forward(bytes, 5);
 
             assert_eq!(result, Some((8, b'4')));
+        }
+
+        #[test]
+        fn seeking_from_whitespace_when_there_is_no_more_non_whitespace_returns_none() {
+            let bytes = "seek: \t\n ".as_bytes();
+
+            let result = in_slice::seek_non_whitespace_forward(bytes, 5);
+
+            assert_eq!(result, None);
         }
     }
 

--- a/crates/rsonpath-lib/src/input/borrowed.rs
+++ b/crates/rsonpath-lib/src/input/borrowed.rs
@@ -101,13 +101,8 @@ impl<'a> Input for BorrowedBytes<'a> {
     }
 
     #[inline]
-    fn seek_forward(&self, from: usize, needle: u8) -> Result<Option<usize>, InputError> {
-        Ok(in_slice::seek_forward(self.bytes, from, needle))
-    }
-
-    #[inline]
-    fn seek_forward_2(&self, from: usize, needle_1: u8, needle_2: u8) -> Result<Option<usize>, InputError> {
-        Ok(in_slice::seek_forward_2(self.bytes, from, needle_1, needle_2))
+    fn seek_forward<const N: usize>(&self, from: usize, needles: [u8; N]) -> Result<Option<(usize, u8)>, InputError> {
+        Ok(in_slice::seek_forward(self.as_slice(), from, needles))
     }
 
     #[inline]

--- a/crates/rsonpath-lib/src/input/borrowed.rs
+++ b/crates/rsonpath-lib/src/input/borrowed.rs
@@ -101,6 +101,16 @@ impl<'a> Input for BorrowedBytes<'a> {
     }
 
     #[inline]
+    fn seek_forward(&self, from: usize, needle: u8) -> Result<Option<usize>, InputError> {
+        Ok(in_slice::seek_forward(self.bytes, from, needle))
+    }
+
+    #[inline]
+    fn seek_forward_2(&self, from: usize, needle_1: u8, needle_2: u8) -> Result<Option<usize>, InputError> {
+        Ok(in_slice::seek_forward_2(self.bytes, from, needle_1, needle_2))
+    }
+
+    #[inline]
     fn seek_non_whitespace_forward(&self, from: usize) -> Result<Option<(usize, u8)>, InputError> {
         Ok(in_slice::seek_non_whitespace_forward(self.bytes, from))
     }

--- a/crates/rsonpath-lib/src/input/buffered.rs
+++ b/crates/rsonpath-lib/src/input/buffered.rs
@@ -138,6 +138,48 @@ impl<R: Read> Input for BufferedInput<R> {
     }
 
     #[inline]
+    fn seek_forward(&self, from: usize, needle: u8) -> Result<Option<usize>, InputError> {
+        let mut buf = self.0.borrow_mut();
+        let mut moving_from = from;
+
+        loop {
+            let res = {
+                let slice = buf.as_slice();
+                in_slice::seek_forward(slice, moving_from, needle)
+            };
+
+            moving_from = buf.len();
+
+            if res.is_some() {
+                return Ok(res);
+            } else if !buf.read_more()? {
+                return Ok(None);
+            }
+        }
+    }
+
+    #[inline]
+    fn seek_forward_2(&self, from: usize, needle_1: u8, needle_2: u8) -> Result<Option<usize>, InputError> {
+        let mut buf = self.0.borrow_mut();
+        let mut moving_from = from;
+
+        loop {
+            let res = {
+                let slice = buf.as_slice();
+                in_slice::seek_forward_2(slice, moving_from, needle_1, needle_2)
+            };
+
+            moving_from = buf.len();
+
+            if res.is_some() {
+                return Ok(res);
+            } else if !buf.read_more()? {
+                return Ok(None);
+            }
+        }
+    }
+
+    #[inline]
     fn seek_non_whitespace_forward(&self, from: usize) -> Result<Option<(usize, u8)>, InputError> {
         let mut buf = self.0.borrow_mut();
         let mut moving_from = from;

--- a/crates/rsonpath-lib/src/input/buffered.rs
+++ b/crates/rsonpath-lib/src/input/buffered.rs
@@ -138,35 +138,14 @@ impl<R: Read> Input for BufferedInput<R> {
     }
 
     #[inline]
-    fn seek_forward(&self, from: usize, needle: u8) -> Result<Option<usize>, InputError> {
+    fn seek_forward<const N: usize>(&self, from: usize, needles: [u8; N]) -> Result<Option<(usize, u8)>, InputError> {
         let mut buf = self.0.borrow_mut();
         let mut moving_from = from;
 
         loop {
             let res = {
                 let slice = buf.as_slice();
-                in_slice::seek_forward(slice, moving_from, needle)
-            };
-
-            moving_from = buf.len();
-
-            if res.is_some() {
-                return Ok(res);
-            } else if !buf.read_more()? {
-                return Ok(None);
-            }
-        }
-    }
-
-    #[inline]
-    fn seek_forward_2(&self, from: usize, needle_1: u8, needle_2: u8) -> Result<Option<usize>, InputError> {
-        let mut buf = self.0.borrow_mut();
-        let mut moving_from = from;
-
-        loop {
-            let res = {
-                let slice = buf.as_slice();
-                in_slice::seek_forward_2(slice, moving_from, needle_1, needle_2)
+                in_slice::seek_forward(slice, moving_from, needles)
             };
 
             moving_from = buf.len();

--- a/crates/rsonpath-lib/src/input/mmap.rs
+++ b/crates/rsonpath-lib/src/input/mmap.rs
@@ -62,13 +62,8 @@ impl Input for MmapInput {
     }
 
     #[inline]
-    fn seek_forward(&self, from: usize, needle: u8) -> Result<Option<usize>, InputError> {
-        Ok(in_slice::seek_forward(&self.mmap, from, needle))
-    }
-
-    #[inline]
-    fn seek_forward_2(&self, from: usize, needle_1: u8, needle_2: u8) -> Result<Option<usize>, InputError> {
-        Ok(in_slice::seek_forward_2(&self.mmap, from, needle_1, needle_2))
+    fn seek_forward<const N: usize>(&self, from: usize, needles: [u8; N]) -> Result<Option<(usize, u8)>, InputError> {
+        Ok(in_slice::seek_forward(&self.mmap, from, needles))
     }
 
     #[inline]

--- a/crates/rsonpath-lib/src/input/mmap.rs
+++ b/crates/rsonpath-lib/src/input/mmap.rs
@@ -62,6 +62,16 @@ impl Input for MmapInput {
     }
 
     #[inline]
+    fn seek_forward(&self, from: usize, needle: u8) -> Result<Option<usize>, InputError> {
+        Ok(in_slice::seek_forward(&self.mmap, from, needle))
+    }
+
+    #[inline]
+    fn seek_forward_2(&self, from: usize, needle_1: u8, needle_2: u8) -> Result<Option<usize>, InputError> {
+        Ok(in_slice::seek_forward_2(&self.mmap, from, needle_1, needle_2))
+    }
+
+    #[inline]
     fn seek_non_whitespace_forward(&self, from: usize) -> Result<Option<(usize, u8)>, InputError> {
         Ok(in_slice::seek_non_whitespace_forward(&self.mmap, from))
     }

--- a/crates/rsonpath-lib/src/input/owned.rs
+++ b/crates/rsonpath-lib/src/input/owned.rs
@@ -233,13 +233,8 @@ impl Input for OwnedBytes {
     }
 
     #[inline]
-    fn seek_forward(&self, from: usize, needle: u8) -> Result<Option<usize>, InputError> {
-        Ok(in_slice::seek_forward(self.as_slice(), from, needle))
-    }
-
-    #[inline]
-    fn seek_forward_2(&self, from: usize, needle_1: u8, needle_2: u8) -> Result<Option<usize>, InputError> {
-        Ok(in_slice::seek_forward_2(self.as_slice(), from, needle_1, needle_2))
+    fn seek_forward<const N: usize>(&self, from: usize, needles: [u8; N]) -> Result<Option<(usize, u8)>, InputError> {
+        Ok(in_slice::seek_forward(self.as_slice(), from, needles))
     }
 
     #[inline]

--- a/crates/rsonpath-lib/src/input/owned.rs
+++ b/crates/rsonpath-lib/src/input/owned.rs
@@ -233,6 +233,16 @@ impl Input for OwnedBytes {
     }
 
     #[inline]
+    fn seek_forward(&self, from: usize, needle: u8) -> Result<Option<usize>, InputError> {
+        Ok(in_slice::seek_forward(self.as_slice(), from, needle))
+    }
+
+    #[inline]
+    fn seek_forward_2(&self, from: usize, needle_1: u8, needle_2: u8) -> Result<Option<usize>, InputError> {
+        Ok(in_slice::seek_forward_2(self.as_slice(), from, needle_1, needle_2))
+    }
+
+    #[inline]
     fn seek_non_whitespace_forward(&self, from: usize) -> Result<Option<(usize, u8)>, InputError> {
         Ok(in_slice::seek_non_whitespace_forward(self.as_slice(), from))
     }

--- a/crates/rsonpath-lib/src/query/error.rs
+++ b/crates/rsonpath-lib/src/query/error.rs
@@ -68,7 +68,7 @@ pub enum ParserError {
     ArrayIndexError(#[from] ArrayIndexError),
 }
 
-///Errors raised trying to parse array indices.
+/// Errors raised trying to parse array indices.
 #[derive(Debug, Error)]
 pub enum ArrayIndexError {
     /// A value in excess of the permitted size was specified.

--- a/crates/rsonpath-lib/src/result.rs
+++ b/crates/rsonpath-lib/src/result.rs
@@ -45,20 +45,20 @@ pub trait QueryResultBuilder<'i, I: Input, R: QueryResult> {
 
     /// Report a match of the query. The `index` is guaranteed to be between the first character
     /// of the matched value and the previous structural character.
-    /// 
+    ///
     /// When the engine finds a match, it will usually occur at some structural character.
     /// It is guaranteed that `index` points to either:
     /// 1. the first character of the matched value; or
     /// 2. the colon or comma structural character directly preceding the matched value; or
     /// 3. a whitespace character before the matched value, such that the next non-whitespace
     /// character is the first character of the matched value.
-    /// 
+    ///
     /// The builder should use the `index` and the provided `hint` to find the start of the
     /// actual value being reported. Note that it is always possible to do so without the hint
     /// (or, equivalently, when [`NodeTypeHint::Any`] is given), but the hint can improve performance.
     /// For example, when the hint is [`NodeTypeHint::Complex`] with the curly bracket type, the
     /// result builder can do a quick direct search for the next '{' character.
-    /// 
+    ///
     /// ```json
     /// {
     ///   "match":       42
@@ -66,7 +66,7 @@ pub trait QueryResultBuilder<'i, I: Input, R: QueryResult> {
     ///   // any of these characters can be reported for the query $.match
     /// }
     /// ```
-    /// 
+    ///
     /// ```json
     /// {
     ///   "match": [42,     30]
@@ -74,11 +74,11 @@ pub trait QueryResultBuilder<'i, I: Input, R: QueryResult> {
     ///   // any of these characters can be reported for the query $.match[1]
     /// }
     /// ```
-    /// 
+    ///
     /// # Errors
     /// This function may access the input, which can raise an [`EngineError::InputError`].
     /// Mo
-    /// 
+    ///
     fn report(&mut self, index: usize, hint: NodeTypeHint) -> Result<(), EngineError>;
 
     /// Finish building the result and return it.

--- a/crates/rsonpath-lib/src/result.rs
+++ b/crates/rsonpath-lib/src/result.rs
@@ -1,24 +1,101 @@
 //! Result types that can be returned by a JSONPath query engine.
-use crate::debug;
+use crate::{classification::structural::BracketType, debug, engine::error::EngineError, input::Input};
 use std::fmt::{self, Display};
 
-/// Result that can be reported during query execution.
+/// Hint given by the engine to a [`QueryResultBuilder`] as to what type of node was matched.
+///
+/// Since the byte offset given by the engine is not stable and can fall anywhere between
+/// the actual value's start and the preceding structural character, this helps a builder quickly
+/// advance to the actual value and parse it.
+///
+/// This is non_exhaustive, since we may add more hints for performance reasons, and the implementations
+/// are already forced to handle the [`Any`](`NodeTypeHint::Any`) variant. The behavior for "unknown"
+/// hints should be the same as for [`Any`](`NodeTypeHint::Any`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum NodeTypeHint {
+    /// The value is any atom (number, string, boolean, null).
+    Atomic,
+    /// The value is an object or an array, and we know what type of bracket to look for.
+    Complex(BracketType),
+    /// The value is an object or an array, but we do not know which. The builder should seek for a '{' *or* '['.
+    AnyComplex,
+    /// The value can be any JSON value, we know nothing more.
+    Any,
+}
+
+/// Result that can be built with some [`QueryResultBuilder`] and returned from a query run.
 pub trait QueryResult: Default + Display + PartialEq {
-    /// Report a match of the query.
-    fn report(&mut self, index: usize);
+    /// The associated type of the builder.
+    type Builder<'i, I: Input + 'i>: QueryResultBuilder<'i, I, Self>;
+}
+
+/// A builder for a [`QueryResult`] with access to the underlying input.
+pub trait QueryResultBuilder<'i, I: Input, R: QueryResult> {
+    /// Create a new, empty builder, with access to the underlying JSON input.
+    ///
+    /// Implementations should make sure that the result produced from an empty builder
+    /// is the same as the empty instance of that result (defined by the [`Default`] trait).
+    /// In other words, for any `builder` of result type `R` it should hold that:
+    ///
+    /// ```ignore
+    /// builder.new(input).finish() == R::default()
+    /// ```
+    fn new(input: &'i I) -> Self;
+
+    /// Report a match of the query. The `index` is guaranteed to be between the first character
+    /// of the matched value and the previous structural character.
+    /// 
+    /// When the engine finds a match, it will usually occur at some structural character.
+    /// It is guaranteed that `index` points to either:
+    /// 1. the first character of the matched value; or
+    /// 2. the colon or comma structural character directly preceding the matched value; or
+    /// 3. a whitespace character before the matched value, such that the next non-whitespace
+    /// character is the first character of the matched value.
+    /// 
+    /// The builder should use the `index` and the provided `hint` to find the start of the
+    /// actual value being reported. Note that it is always possible to do so without the hint
+    /// (or, equivalently, when [`NodeTypeHint::Any`] is given), but the hint can improve performance.
+    /// For example, when the hint is [`NodeTypeHint::Complex`] with the curly bracket type, the
+    /// result builder can do a quick direct search for the next '{' character.
+    /// 
+    /// ```json
+    /// {
+    ///   "match":       42
+    ///   //     ^^^^^^^^^
+    ///   // any of these characters can be reported for the query $.match
+    /// }
+    /// ```
+    /// 
+    /// ```json
+    /// {
+    ///   "match": [42,     30]
+    ///   //          ^^^^^^^
+    ///   // any of these characters can be reported for the query $.match[1]
+    /// }
+    /// ```
+    /// 
+    /// # Errors
+    /// This function may access the input, which can raise an [`EngineError::InputError`].
+    /// Mo
+    /// 
+    fn report(&mut self, index: usize, hint: NodeTypeHint) -> Result<(), EngineError>;
+
+    /// Finish building the result and return it.
+    fn finish(self) -> R;
 }
 
 /// Result informing on the number of values matching the executed query.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CountResult {
-    count: usize,
+    count: u64,
 }
 
 impl CountResult {
     /// Number of values matched by the executed query.
     #[must_use]
     #[inline(always)]
-    pub fn get(&self) -> usize {
+    pub fn get(&self) -> u64 {
         self.count
     }
 }
@@ -31,15 +108,37 @@ impl Display for CountResult {
 }
 
 impl QueryResult for CountResult {
+    type Builder<'i, I: Input + 'i> = CountResultBuilder;
+}
+
+/// The [`QueryResultBuilder`] for [`CountResult`].
+#[must_use]
+pub struct CountResultBuilder {
+    count: u64,
+}
+
+impl<'i, I: Input> QueryResultBuilder<'i, I, CountResult> for CountResultBuilder {
     #[inline(always)]
-    fn report(&mut self, _item: usize) {
+    fn new(_input: &'i I) -> Self {
+        Self { count: 0 }
+    }
+
+    #[inline(always)]
+    fn report(&mut self, _item: usize, _hint: NodeTypeHint) -> Result<(), EngineError> {
         debug!("Reporting result: {_item}");
         self.count += 1;
+
+        Ok(())
+    }
+
+    #[must_use]
+    #[inline(always)]
+    fn finish(self) -> CountResult {
+        CountResult { count: self.count }
     }
 }
 
-/// Query result containing all indices of colons that constitute a
-/// match.
+/// Query result containing all indices of colons that constitute a match.
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IndexResult {
     indices: Vec<usize>,
@@ -69,9 +168,46 @@ impl Display for IndexResult {
 }
 
 impl QueryResult for IndexResult {
+    type Builder<'i, I: Input + 'i> = IndexResultBuilder<'i, I>;
+}
+
+/// The [`QueryResultBuilder`] for [`IndexResult`].
+#[must_use]
+pub struct IndexResultBuilder<'i, I> {
+    input: &'i I,
+    indices: Vec<usize>,
+}
+
+impl<'i, I: Input> QueryResultBuilder<'i, I, IndexResult> for IndexResultBuilder<'i, I> {
     #[inline(always)]
-    fn report(&mut self, item: usize) {
-        debug!("Reporting result: {item}");
-        self.indices.push(item);
+    fn new(input: &'i I) -> Self {
+        Self { input, indices: vec![] }
+    }
+
+    #[inline(always)]
+    fn report(&mut self, item: usize, hint: NodeTypeHint) -> Result<(), EngineError> {
+        debug!("Reporting result: {item} with hint {hint:?}");
+
+        let index = match hint {
+            NodeTypeHint::Complex(BracketType::Curly) => self.input.seek_forward(item, b'{')?,
+            NodeTypeHint::Complex(BracketType::Square) => self.input.seek_forward(item, b'[')?,
+            NodeTypeHint::AnyComplex | NodeTypeHint::Any | NodeTypeHint::Atomic => {
+                self.input.seek_non_whitespace_forward(item)?.map(|x| x.0)
+            }
+        };
+
+        match index {
+            Some(idx) => {
+                self.indices.push(idx);
+                Ok(())
+            }
+            None => Err(EngineError::MissingItem()),
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    fn finish(self) -> IndexResult {
+        IndexResult { indices: self.indices }
     }
 }

--- a/crates/rsonpath-lib/tests/engine_correctness_tests.rs
+++ b/crates/rsonpath-lib/tests/engine_correctness_tests.rs
@@ -205,7 +205,7 @@ macro_rules! count_test_cases {
             "wikidata/wikidata_properties.json", "$..P7103.claims.P31..references..snaks.P4656..hash" => 1;
             "wikidata_properties.json $..P7103.claims.P31..references..snaks.P4656..hash"
         )]
-        fn $test_name(test_path: &str, query_string: &str) -> usize {
+        fn $test_name(test_path: &str, query_string: &str) -> u64 {
             let contents = get_contents(test_path);
             let query = JsonPathQuery::parse(query_string).unwrap();
             let result = $impl::compile_query(&query).unwrap().run::<_, CountResult>(&contents).unwrap();
@@ -228,12 +228,12 @@ macro_rules! indices_test_cases {
         #[test_case("basic/array_root.json", "$[0]" => Vec::<usize>::new(); "array_root.json nneg array index simple")]
         #[test_case("basic/array_root_singleton.json", "$[0]" => vec![1]; "array_root_singleton.json nneg array index simple")]
         #[test_case("basic/child.json", "$..a..b.c..d" => vec![984, 1297, 1545]; "child.json $..a..b.c..d")]
-        #[test_case("basic/child_hell.json", "$..x..a.b.a.b.c" => vec![198, 756, 1227, 1903, 2040, 2207]; "child_hell.json $..x..a.b.a.b.c")]
+        #[test_case("basic/child_hell.json", "$..x..a.b.a.b.c" => vec![198, 758, 1227, 1903, 2040, 2207]; "child_hell.json $..x..a.b.a.b.c")]
         #[test_case("basic/empty.json", "" => Vec::<usize>::new(); "empty.json")]
         #[test_case("basic/empty.json", "$" => Vec::<usize>::new(); "empty.json $")]
         #[test_case("basic/escapes.json", r#"$..a..b..['label\\']"# => vec![609]; "escapes.json existing label")]
         #[test_case("basic/escapes.json", r#"$..a..b..['label\\\\']"# => Vec::<usize>::new(); "escapes.json nonexistent label")]
-        #[test_case("basic/heterogeneous_list.json", r#"$.a.*"# => vec![10, 23, 44]; "heterogeneous_list.json $.a.*")]
+        #[test_case("basic/heterogeneous_list.json", r#"$.a.*"# => vec![15, 23, 44]; "heterogeneous_list.json $.a.*")]
         #[test_case("basic/memchr_trap.json", "$..b" => vec![43]; "memchr_trap.json $..b")]
         #[test_case("basic/memchr_trap.json", r#"$..['"b']"# => vec![26]; r#"memchr_trap.json $..['"b']"#)]
         #[test_case("basic/quote_escape.json", r#"$['"x']"# => vec![11]; "quote_escape.json with quote")]
@@ -246,27 +246,27 @@ macro_rules! indices_test_cases {
         #[test_case("basic/small_no_list.json", "$..person..phoneNumber..number" => vec![310, 764]; "small_no_list.json $..person..phoneNumber..number")]
         #[test_case("basic/small.json", "$..person..phoneNumber..number" => vec![332, 436, 934, 1070]; "small.json $..person..phoneNumber..number")]
         #[test_case("basic/spaced_colon.json", r#"$..a..b..label"# => vec![106, 213]; "spaced colon")]
-        #[test_case("basic/wildcard_list.json", r#"$..a.*"# => vec![46, 64, 101, 121, 141, 287]; "wildcard_list.json $..a.*")]
-        #[test_case("basic/wildcard_list2.json", r#"$..a.*..b.*"# => vec![226, 364, 402, 479, 519, 559, 641, 881]; "wildcard_list2.json $..a.*..b.*")]
-        #[test_case("basic/wildcard_list2.json", r#"$..a..*..b..*"# => vec![226, 364, 402, 479, 519, 559, 601, 641, 881]; "wildcard_list2.json any descendant $..a..*..b..*")]
-        #[test_case("basic/wildcard_object.json", r#"$..a.*"# => vec![66, 91, 116, 143, 211, 238, 267]; "wildcard_object.json $..a.*")]
+        #[test_case("basic/wildcard_list.json", r#"$..a.*"# => vec![63, 64, 101, 121, 141, 287]; "wildcard_list.json $..a.*")]
+        #[test_case("basic/wildcard_list2.json", r#"$..a.*..b.*"# => vec![226, 401, 402, 479, 519, 559, 641, 881]; "wildcard_list2.json $..a.*..b.*")]
+        #[test_case("basic/wildcard_list2.json", r#"$..a..*..b..*"# => vec![226, 401, 402, 479, 519, 559, 601, 641, 881]; "wildcard_list2.json any descendant $..a..*..b..*")]
+        #[test_case("basic/wildcard_object.json", r#"$..a.*"# => vec![66, 91, 116, 143, 213, 238, 267]; "wildcard_object.json $..a.*")]
         #[test_case("basic/wildcard_object2.json", r#"$..a.*.*..b.*.*"# => vec![652, 709, 751, 791, 855, 901, 1713, 1811, 1878]; "wildcard_object2.json $..a.*.*..b.*.*")]
         #[test_case("basic/wildcard_object2.json", r#"$..a..*..*..b..*..*"# => vec![652, 709, 751, 791, 855, 901, 945, 1016, 1067, 1115, 1193, 1248, 1300, 1385, 1443, 1499, 1590, 1653, 1713, 1811, 1878, 1942, 2048]; "wildcard_object2.json any descendant $..a..*..*..b..*..*")]
         #[test_case(
             "twitter/twitter.json",
             "$..user..entities..url"
-                => vec![5463, 5568, 9494, 9983, 18494, 18599, 23336, 23441, 24015, 89783, 89900, 112196, 112313, 134218, 134335, 134934, 201053, 201158, 205279, 205396, 206006, 333128, 333233, 352430, 352535, 353094, 356998, 357115, 399783, 399900, 451852, 475582, 475687, 511440, 511545, 516536, 516641, 728250, 728355, 743600, 743717, 762795, 762900, 763472];
+                => vec![5465, 5568, 9494, 9983, 18496, 18599, 23338, 23441, 24015, 89785, 89900, 112198, 112313, 134220, 134335, 134934, 201055, 201158, 205281, 205396, 206006, 333130, 333233, 352432, 352535, 353094, 357000, 357115, 399785, 399900, 451852, 475584, 475687, 511442, 511545, 516538, 516641, 728252, 728355, 743602, 743717, 762797, 762900, 763472];
             "twitter.json $..user..entities..url (recursive)")]
         #[test_case(
             "twitter/twitter.json",
             "$..user..entities.url"
-                => vec![5463, 18494, 23336, 89783, 112196, 134218, 201053, 205279, 333128, 352430, 356998, 399783, 475582, 511440, 516536, 728250, 743600, 762795];
+                => vec![5465, 18496, 23338, 89785, 112198, 134220, 201055, 205281, 333130, 352432, 357000, 399785, 475584, 511442, 516538, 728252, 743602, 762797];
             "twitter.json $..user..entities.url (child)")]
         #[test_case("twitter/twitter_urls.json", "$..entities..urls..url" => vec![321, 881]; "twitter_urls.json $..entities..urls..url")]
         #[test_case("twitter/twitter_urls.json", "$..entities.urls..url" => vec![321, 881]; "twitter_urls.json $..entities.urls..url (child)")]
         #[test_case("basic/compressed/child.json", "$..a..b.c..d" => vec![99, 132, 152]; "compressed child.json $..a..b.c..d")]
         #[test_case("basic/compressed/child.json", "$..*..b.c..*" => vec![99, 128, 132, 152]; "compressed child.json any descendant $..*..b.c..*")]
-        #[test_case("basic/compressed/child_hell.json", "$..x..a.b.a.b.c" => vec![39, 108, 189, 240, 263, 280]; "compressed child_hell.json $..x..a.b.a.b.c")]
+        #[test_case("basic/compressed/child_hell.json", "$..x..a.b.a.b.c" => vec![39, 109, 189, 240, 263, 280]; "compressed child_hell.json $..x..a.b.a.b.c")]
         #[test_case("basic/compressed/escapes.json", r#"$..a..b..['label\\']"# => vec![524]; "compressed escapes.json existing label")]
         #[test_case("basic/compressed/escapes.json", r#"$..a..b..['label\\\\']"# => Vec::<usize>::new(); "compressed escapes.json nonexistent label")]
         #[test_case("basic/compressed/memchr_trap.json", "$..b" => vec![18]; "compressed memchr_trap.json $..b")]
@@ -285,12 +285,12 @@ macro_rules! indices_test_cases {
         #[test_case(
             "twitter/compressed/twitter.json",
             "$..user..entities..url"
-                => vec![3487, 3503, 5802, 5954, 9835, 9851, 12717, 12733, 12912, 52573, 52589, 64602, 64618, 77996, 78012, 78164, 119306, 119322, 121917, 121933, 122096, 201072, 201088, 212697, 212713, 212877, 215342, 215358, 241825, 241841, 274277, 288268, 288284, 310029, 310045, 312971, 312987, 445430, 445446, 454459, 454475, 464575, 464591, 464768];
+                => vec![3488, 3503, 5802, 5954, 9836, 9851, 12718, 12733, 12912, 52574, 52589, 64603, 64618, 77997, 78012, 78164, 119307, 119322, 121918, 121933, 122096, 201073, 201088, 212698, 212713, 212877, 215343, 215358, 241826, 241841, 274277, 288269, 288284, 310030, 310045, 312972, 312987, 445431, 445446, 454460, 454475, 464576, 464591, 464768];
             "compressed twitter.json $..user..entities..url (recursive)")]
         #[test_case(
             "twitter/compressed/twitter.json",
             "$..user..entities.url"
-                => vec![3487, 9835, 12717, 52573, 64602, 77996, 119306, 121917, 201072, 212697, 215342, 241825, 288268, 310029, 312971, 445430, 454459, 464575];
+                => vec![3488, 9836, 12718, 52574, 64603, 77997, 119307, 121918, 201073, 212698, 215343, 241826, 288269, 310030, 312972, 445431, 454460, 464576];
             "compressed twitter.json $..user..entities.url (child)")]
         #[test_case("twitter/compressed/twitter_urls.json", "$..entities..urls..url" => vec![145, 326]; "compressed twitter_urls.json $..entities..urls..url")]
         #[test_case("twitter/compressed/twitter_urls.json", "$..[0]" => vec![1, 139, 183, 249, 320, 364]; "compressed twitter_urls.json nneg array first descendent")]

--- a/crates/rsonpath/src/error.rs
+++ b/crates/rsonpath/src/error.rs
@@ -49,6 +49,7 @@ pub fn report_engine_error(error: EngineError) -> eyre::Report {
             add_unsupported_context(eyre::Report::new(error), UnsupportedFeatureError::large_json_depths())
         }
         EngineError::MissingClosingCharacter() => eyre::Report::new(error),
+        EngineError::MissingItem() => eyre::Report::new(error),
         EngineError::MalformedStringQuotes(_) => eyre::Report::new(error),
         EngineError::NotSupported(unsupported) => report_unsupported_error(unsupported),
         EngineError::InternalError(_) => eyre::Report::new(error),


### PR DESCRIPTION
The `--result bytes` mode now consistently reports the first byte of the value it matched. This can be used to extract the actual value from the JSON by parsing from the reported byte.

## Issue

Resolves: #161

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.