### PR TITLE
feat!: remove the unique-members feature

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -84,8 +84,7 @@
     "lldb.dereferencePointers": true,
     "lldb.consoleMode": "commands",
     "rust-analyzer.cargo.features": [
-        // "simd",
-        "unique-members"
+        "simd"
     ],
     "rust-analyzer.cargo.noDefaultFeatures": true,
     "rust-analyzer.cargo.allFeatures": false,

--- a/README.md
+++ b/README.md
@@ -145,15 +145,6 @@ the engine will simply match the _first_ such key.
 [6]
 ```
 
-This behavior can be overriden with a custom installation of `rsonpath`, disabling the default `unique-members` feature. This will hurt performance.
-
-```bash
-> cargo install rsonpath --no-default-features -F simd -F head-skip -F tail-skip
-> rq '$.key'
-{"key":"value","key":"other value"}
-[6, 20]
-```
-
 ### Unicode
 
 The engine does _not_ parse unicode escape sequences in member names.

--- a/crates/rsonpath-lib/Cargo.toml
+++ b/crates/rsonpath-lib/Cargo.toml
@@ -41,6 +41,5 @@ proptest = "1.2.0"
 test-case = "3.1.0"
 
 [features]
-default = ["simd", "unique-members"]
+default = ["simd"]
 simd = []
-unique-members = []

--- a/crates/rsonpath-lib/src/engine/main.rs
+++ b/crates/rsonpath-lib/src/engine/main.rs
@@ -315,25 +315,22 @@ where
             if !any_matched && self.automaton.is_accepting(fallback_state) {
                 self.record_match_detected_at(idx + 1, NodeTypeHint::Atomic /* since is_next_opening is false */)?;
             }
-            #[cfg(feature = "unique-members")]
-            {
-                self.next_event = classifier.next()?;
-                let is_next_closing = self.next_event.map_or(false, |s| s.is_closing());
-                if any_matched && !is_next_closing && self.automaton.is_unitary(self.state) {
-                    if let Some(s) = self.next_event {
-                        match s {
-                            Structural::Closing(_, idx) => {
-                                self.recorder.record_value_terminator(idx, self.depth)?;
-                            }
-                            Structural::Comma(idx) => self.recorder.record_value_terminator(idx, self.depth)?,
-                            Structural::Colon(_) | Structural::Opening(_, _) => (),
+            self.next_event = classifier.next()?;
+            let is_next_closing = self.next_event.map_or(false, |s| s.is_closing());
+            if any_matched && !is_next_closing && self.automaton.is_unitary(self.state) {
+                if let Some(s) = self.next_event {
+                    match s {
+                        Structural::Closing(_, idx) => {
+                            self.recorder.record_value_terminator(idx, self.depth)?;
                         }
+                        Structural::Comma(idx) => self.recorder.record_value_terminator(idx, self.depth)?,
+                        Structural::Colon(_) | Structural::Opening(_, _) => (),
                     }
-                    let bracket_type = self.current_node_bracket_type();
-                    debug!("Skipping unique state from {bracket_type:?}");
-                    let stop_at = classifier.skip(bracket_type)?;
-                    self.next_event = Some(Structural::Closing(bracket_type, stop_at));
                 }
+                let bracket_type = self.current_node_bracket_type();
+                debug!("Skipping unique state from {bracket_type:?}");
+                let stop_at = classifier.skip(bracket_type)?;
+                self.next_event = Some(Structural::Closing(bracket_type, stop_at));
             }
         }
 
@@ -512,7 +509,6 @@ where
 
             debug!("Restored array count to {}", self.array_count);
 
-            #[cfg(feature = "unique-members")]
             if self.automaton.is_unitary(self.state) {
                 let bracket_type = self.current_node_bracket_type();
                 debug!("Skipping unique state from {bracket_type:?}");
@@ -599,7 +595,6 @@ where
         }
     }
 
-    #[cfg(feature = "unique-members")]
     fn current_node_bracket_type(&self) -> BracketType {
         if self.is_list {
             BracketType::Square

--- a/crates/rsonpath/Cargo.toml
+++ b/crates/rsonpath/Cargo.toml
@@ -37,7 +37,5 @@ rustflags = { version = "0.1.4" }
 vergen = { version = "8.2.4", features = ["cargo", "git", "gitcl", "rustc"] }
 
 [features]
-default = ["simd", "default-optimizations"]
+default = ["simd"]
 simd = ["rsonpath-lib/simd"]
-unique-members = ["rsonpath-lib/unique-members"]
-default-optimizations = ["unique-members"]

--- a/rsonpath.code-workspace
+++ b/rsonpath.code-workspace
@@ -77,8 +77,7 @@
 		"lldb.dereferencePointers": true,
 		"lldb.consoleMode": "commands",
 		"rust-analyzer.cargo.features": [
-			"simd",
-			"unique-members",
+			"simd"
 		],
 		"rust-analyzer.cargo.noDefaultFeatures": true,
 		"rust-analyzer.cargo.allFeatures": false


### PR DESCRIPTION
## Short description

This feature clutters the API more than anything.
If supporting duplicate keys is required in the future, It can be easily added as a config option,
not a compilation one.

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.