### PR TITLE
Fix: #249 panic during head skipping

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -139,12 +139,12 @@ test-book:
 
 @add-test name:
     f=`echo {{name}} | sed s/-/_/g` && \
-        cp ./crates/rsonpath-lib/tests/documents/toml/test-template-inline.toml ./crates/rsonpath-lib/tests/documents/toml/$f.toml && \
+        cp ./crates/rsonpath-lib/tests/documents/toml/test_template_inline.toml ./crates/rsonpath-lib/tests/documents/toml/$f.toml && \
         echo "Test template initialised at crates/rsonpath-lib/tests/documents/toml/$f.toml"
 
 @add-test-large name:
     f=`echo {{name}} | sed s/-/_/g` && \
-        cp ./crates/rsonpath-lib/tests/documents/toml/test-template-large.toml ./crates/rsonpath-lib/tests/documents/toml/$f.toml && \
+        cp ./crates/rsonpath-lib/tests/documents/toml/test_template_large.toml ./crates/rsonpath-lib/tests/documents/toml/$f.toml && \
         echo "Test template initialised at crates/rsonpath-lib/tests/documents/toml/$f.toml" && \
         echo "{}" > ./crates/rsonpath-lib/tests/documents/json/large/$f.json && \
         echo "Put your large JSON document as contents of crates/rsonpath-lib/tests/documents/json/large/$f.json"

--- a/crates/rsonpath-lib/src/classification.rs
+++ b/crates/rsonpath-lib/src/classification.rs
@@ -129,8 +129,7 @@ where
         let current_idx = current_block_start + current_block_idx;
 
         debug!(
-            "Calling forward_to({index}) when the inner iter offset is {} and block idx is {:?}",
-            current_block_start, current_block_idx
+            "Calling forward_to({index}) when the inner iter offset is {current_block_start} and block idx is {current_block_idx:?}"
         );
 
         // We want to move by this much forward, and delta > 0.

--- a/crates/rsonpath-lib/src/classification/memmem/avx2_64.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/avx2_64.rs
@@ -1,5 +1,3 @@
-use log::debug;
-
 use super::{shared::mask_64, shared::vector_256, *};
 use crate::{
     classification::mask::m64,
@@ -119,7 +117,6 @@ where
         label: &JsonString,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         if let Some(b) = first_block {
-            debug!("Looking at the first_block first...");
             if let Some(res) = shared::find_label_in_first_block(self.input, b, start_idx, label)? {
                 return Ok(Some(res));
             }

--- a/crates/rsonpath-lib/src/classification/memmem/avx2_64.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/avx2_64.rs
@@ -1,3 +1,5 @@
+use log::debug;
+
 use super::{shared::mask_64, shared::vector_256, *};
 use crate::{
     classification::mask::m64,
@@ -117,6 +119,7 @@ where
         label: &JsonString,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         if let Some(b) = first_block {
+            debug!("Looking at the first_block first...");
             if let Some(res) = shared::find_label_in_first_block(self.input, b, start_idx, label)? {
                 return Ok(Some(res));
             }

--- a/crates/rsonpath-lib/src/classification/quotes.rs
+++ b/crates/rsonpath-lib/src/classification/quotes.rs
@@ -63,8 +63,11 @@ pub trait QuoteClassifiedIterator<'i, I: InputBlockIterator<'i, N>, M, const N: 
     fn get_offset(&self) -> usize;
 
     /// Move the iterator `count` blocks forward.
-    /// Effectively skips `count * Twice<BlockAlignment>::size()` bytes.
-    fn offset(&mut self, count: isize);
+    ///
+    /// # Errors
+    /// At least one new block is read from the underlying
+    /// [`InputBlockIterator`] implementation, which can fail.
+    fn offset(&mut self, count: isize) -> Result<Option<QuoteClassifiedBlock<I::Block, M, N>>, InputError>;
 
     /// Flip the bit representing whether the last block ended with a nonescaped quote.
     ///

--- a/crates/rsonpath-lib/src/classification/quotes.rs
+++ b/crates/rsonpath-lib/src/classification/quotes.rs
@@ -38,6 +38,10 @@ use crate::{
 };
 use cfg_if::cfg_if;
 
+/// Result of the [`FallibleIterator`] for quote classification,
+/// and of the [`offset`](`QuoteClassifiedIterator::offset`) function.
+pub type QuoteIterResult<I, M, const N: usize> = Result<Option<QuoteClassifiedBlock<I, M, N>>, InputError>;
+
 /// Input block with a bitmask signifying which characters are within quotes.
 ///
 /// Characters within quotes in the input are guaranteed to have their corresponding
@@ -67,7 +71,7 @@ pub trait QuoteClassifiedIterator<'i, I: InputBlockIterator<'i, N>, M, const N: 
     /// # Errors
     /// At least one new block is read from the underlying
     /// [`InputBlockIterator`] implementation, which can fail.
-    fn offset(&mut self, count: isize) -> Result<Option<QuoteClassifiedBlock<I::Block, M, N>>, InputError>;
+    fn offset(&mut self, count: isize) -> QuoteIterResult<I::Block, M, N>;
 
     /// Flip the bit representing whether the last block ended with a nonescaped quote.
     ///

--- a/crates/rsonpath-lib/src/classification/quotes/nosimd.rs
+++ b/crates/rsonpath-lib/src/classification/quotes/nosimd.rs
@@ -107,15 +107,15 @@ where
         self.iter.get_offset() - N
     }
 
-    fn offset(&mut self, count: isize) {
-        debug_assert!(count >= 0);
+    fn offset(&mut self, count: isize) -> Result<Option<QuoteClassifiedBlock<I::Block, usize, N>>, InputError> {
+        debug_assert!(count > 0);
         debug!("Offsetting by {count}");
 
-        if count == 0 {
-            return;
+        for _ in 0..count - 1 {
+            self.iter.next()?;
         }
 
-        self.iter.offset(count);
+        self.next()
     }
 
     fn flip_quotes_bit(&mut self) {

--- a/crates/rsonpath-lib/src/classification/quotes/nosimd.rs
+++ b/crates/rsonpath-lib/src/classification/quotes/nosimd.rs
@@ -107,7 +107,7 @@ where
         self.iter.get_offset() - N
     }
 
-    fn offset(&mut self, count: isize) -> Result<Option<QuoteClassifiedBlock<I::Block, usize, N>>, InputError> {
+    fn offset(&mut self, count: isize) -> QuoteIterResult<I::Block, usize, N> {
         debug_assert!(count > 0);
         debug!("Offsetting by {count}");
 

--- a/crates/rsonpath-lib/src/classification/quotes/shared.rs
+++ b/crates/rsonpath-lib/src/classification/quotes/shared.rs
@@ -89,15 +89,18 @@ macro_rules! quote_classifier {
                 self.iter.get_offset() - $size
             }
 
-            fn offset(&mut self, count: isize) {
-                debug_assert!(count >= 0);
+            fn offset(
+                &mut self,
+                count: isize,
+            ) -> Result<Option<QuoteClassifiedBlock<I::Block, $mask_ty, $size>>, InputError> {
+                debug_assert!(count > 0);
                 debug!("Offsetting by {count}");
 
-                if count == 0 {
-                    return;
+                for _ in 0..count - 1 {
+                    self.iter.next()?;
                 }
 
-                self.iter.offset(count);
+                self.next()
             }
 
             fn flip_quotes_bit(&mut self) {

--- a/crates/rsonpath-lib/src/classification/quotes/shared.rs
+++ b/crates/rsonpath-lib/src/classification/quotes/shared.rs
@@ -89,10 +89,7 @@ macro_rules! quote_classifier {
                 self.iter.get_offset() - $size
             }
 
-            fn offset(
-                &mut self,
-                count: isize,
-            ) -> Result<Option<QuoteClassifiedBlock<I::Block, $mask_ty, $size>>, InputError> {
+            fn offset(&mut self, count: isize) -> QuoteIterResult<I::Block, $mask_ty, $size> {
                 debug_assert!(count > 0);
                 debug!("Offsetting by {count}");
 

--- a/crates/rsonpath-lib/src/input/borrowed.rs
+++ b/crates/rsonpath-lib/src/input/borrowed.rs
@@ -9,10 +9,8 @@
 //! This type of input is the fastest to process for the engine,
 //! since there is no additional overhead from loading anything to memory.
 
-use log::debug;
-
 use super::*;
-use crate::{query::JsonString, result::InputRecorder};
+use crate::{debug, query::JsonString, result::InputRecorder};
 
 /// Input wrapping a borrowed [`[u8]`] buffer.
 pub struct BorrowedBytes<'a> {

--- a/crates/rsonpath-lib/src/lib.rs
+++ b/crates/rsonpath-lib/src/lib.rs
@@ -244,7 +244,7 @@ macro_rules! block {
                     .map(|x| if x.is_ascii_whitespace() { b' ' } else { *x })
                     .collect::<Vec<_>>()
             )
-            .unwrap()
+            .unwrap_or("[INVALID UTF8]")
         );
     };
 }

--- a/crates/rsonpath-lib/src/query/parser.rs
+++ b/crates/rsonpath-lib/src/query/parser.rs
@@ -355,20 +355,20 @@ mod tests {
 
     #[test]
     fn single_quoted_member_should_not_unescape_backslashes() {
-        let input = r#"\\x"#;
+        let input = r"\\x";
 
         let result = super::single_quoted_member()(input);
 
-        assert_eq!(result, Ok(("", r#"\\x"#.to_owned())));
+        assert_eq!(result, Ok(("", r"\\x".to_owned())));
     }
 
     #[test]
     fn double_quoted_member_should_not_unescape_backslashes() {
-        let input = r#"\\x"#;
+        let input = r"\\x";
 
         let result = super::double_quoted_member()(input);
 
-        assert_eq!(result, Ok(("", r#"\\x"#.to_owned())));
+        assert_eq!(result, Ok(("", r"\\x".to_owned())));
     }
 
     #[test]

--- a/crates/rsonpath-lib/tests/classifier_correctness_tests.rs
+++ b/crates/rsonpath-lib/tests/classifier_correctness_tests.rs
@@ -144,7 +144,7 @@ mod prop_test {
             let escaped_string: String = value
                 .chars()
                 .map(|c| match c {
-                    '\\' => String::from(r#"\\"#),
+                    '\\' => String::from(r"\\"),
                     '"' => String::from(r#"\""#),
                     x => x.to_string(),
                 })
@@ -187,7 +187,7 @@ mod prop_test {
             Just(Token::OpeningBracket),
             Just(Token::ClosingBrace),
             Just(Token::ClosingBracket),
-            r#"[ -!#-+\--9;-Z^-z|~]+"#.prop_map(Token::Garbage), // ascii characters except structural
+            r"[ -!#-+\--9;-Z^-z|~]+".prop_map(Token::Garbage), // ascii characters except structural
             "[ -~]".prop_map(|x| Token::Quoted(QuotedString::from(&x)))  // all ascii characters
         ]
     }

--- a/crates/rsonpath-lib/tests/documents/toml/head_skip_long.toml
+++ b/crates/rsonpath-lib/tests/documents/toml/head_skip_long.toml
@@ -1,0 +1,54 @@
+# Define the JSON input for all query test cases.
+[input]
+# Short description of the input structure.
+description = "Long labels to search with head skipping (issue #249)"
+# Set to true only if your specific test input is fully compressed (no extraneous whitespace).
+is_compressed = false
+
+# Inline JSON document.
+[input.source]
+json_string = '''
+{
+  "target": {
+    "please note the important whitespaces after the upcoming comma (pretend indentation is really big)": 42
+  },                                                   
+  "target" : 43,
+  "very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249": 44
+}
+'''
+
+# Define queries to test on the input.
+[[queries]]
+# First scenario causing the #249 panic - label that is so long that it spans multiple blocks of input.
+query = "$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']"
+# Short descritpion of the query semantics.
+description = "select the extremely long label"
+
+[queries.results]
+# Number of expected matches.
+count = 1
+# Byte locations of starts of all matches, in order.
+bytes = [428]
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = ['44']
+
+[[queries]]
+# Second scenario causing the #249 panic - extremely specific location of tokens, where
+# the end of a subtree (the closing character) is exactly at the end of a block,
+# the key being looked for is found in the next block,
+# but whitespace cause the colon to occur in the next-next block.
+# Trust me, it makes sense.
+query = "$..target"
+description = "select the label starting exactly at block boundary"
+
+[queries.results]
+# Number of expected matches.
+count = 2
+# Byte locations of starts of all matches, in order.
+bytes = [14, 194]
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = ['''{
+    "please note the important whitespaces after the upcoming comma (pretend indentation is really big)": 42
+  }''', '43']

--- a/crates/rsonpath-lib/tests/end_to_end.rs
+++ b/crates/rsonpath-lib/tests/end_to_end.rs
@@ -1,4 +1,4 @@
-// fc8d21b99a7454b201b4bff92524ec24
+// 5dc22515f57ed020ebfab849db867ac9
 use pretty_assertions::assert_eq;
 use rsonpath::engine::{main::MainEngine, Compiler, Engine};
 use rsonpath::input::*;
@@ -10960,6 +10960,507 @@ fn list_with_nested_sublists_to_stress_output_ordering_with_query_select_all_sub
     let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(&x.bytes)).collect();
     let utf8 = utf8.expect("valid utf8");
     let expected: Vec<&str> = vec!["1", "2", "[\n    {},\n    4\n  ]", "{}", "4", "[\n    5\n  ]", "5"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![355usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(&x.bytes)).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["44"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![355usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(&x.bytes)).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["44"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![355usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(&x.bytes)).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["44"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 2u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![10usize, 125usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(&x.bytes)).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![
+        "{\"please note the important whitespaces after the upcoming comma (pretend indentation is really big)\":42}",
+        "43",
+    ];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 2u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![10usize, 125usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(&x.bytes)).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![
+        "{\"please note the important whitespaces after the upcoming comma (pretend indentation is really big)\":42}",
+        "43",
+    ];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 2u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![10usize, 125usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_long.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(&x.bytes)).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![
+        "{\"please note the important whitespaces after the upcoming comma (pretend indentation is really big)\":42}",
+        "43",
+    ];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![428usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(&x.bytes)).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["44"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![428usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(&x.bytes)).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["44"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![428usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(&x.bytes)).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["44"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 2u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![14usize, 194usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(&x.bytes)).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected : Vec < & str > = vec ! ["{\n    \"please note the important whitespaces after the upcoming comma (pretend indentation is really big)\": 42\n  }" , "43" ,] ;
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 2u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![14usize, 194usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(&x.bytes)).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected : Vec < & str > = vec ! ["{\n    \"please note the important whitespaces after the upcoming comma (pretend indentation is really big)\": 42\n  }" , "43" ,] ;
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 2u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![14usize, 194usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..target")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_long.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(&x.bytes)).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected : Vec < & str > = vec ! ["{\n    \"please note the important whitespaces after the upcoming comma (pretend indentation is really big)\": 42\n  }" , "43" ,] ;
     assert_eq!(utf8, expected, "result != expected");
     Ok(())
 }

--- a/crates/rsonpath-lib/tests/end_to_end.rs
+++ b/crates/rsonpath-lib/tests/end_to_end.rs
@@ -1,4 +1,4 @@
-// 5dc22515f57ed020ebfab849db867ac9
+// 031ac21ad8baf84d2d626e0fc1d0f14d
 use pretty_assertions::assert_eq;
 use rsonpath::engine::{main::MainEngine, Compiler, Engine};
 use rsonpath::input::*;
@@ -10964,7 +10964,7 @@ fn list_with_nested_sublists_to_stress_output_ordering_with_query_select_all_sub
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_buffered_input_and_count_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_extremely_long_label_with_buffered_input_and_count_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl BufferedInput and result mode CountResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -10976,7 +10976,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_ext
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_buffered_input_and_index_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_extremely_long_label_with_buffered_input_and_index_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl BufferedInput and result mode IndexResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -10989,7 +10989,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_ext
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_buffered_input_and_nodes_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_extremely_long_label_with_buffered_input_and_nodes_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl BufferedInput and result mode NodesResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11005,7 +11005,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_ext
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_mmap_input_and_count_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_extremely_long_label_with_mmap_input_and_count_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl MmapInput and result mode CountResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11017,7 +11017,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_ext
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_mmap_input_and_index_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_extremely_long_label_with_mmap_input_and_index_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl MmapInput and result mode IndexResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11030,7 +11030,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_ext
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_mmap_input_and_nodes_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_extremely_long_label_with_mmap_input_and_nodes_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl MmapInput and result mode NodesResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11046,7 +11046,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_ext
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_owned_bytes_and_count_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_extremely_long_label_with_owned_bytes_and_count_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl OwnedBytes and result mode CountResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11058,7 +11058,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_ext
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_owned_bytes_and_index_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_extremely_long_label_with_owned_bytes_and_index_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl OwnedBytes and result mode IndexResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11071,7 +11071,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_ext
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_extremely_long_label_with_owned_bytes_and_nodes_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_extremely_long_label_with_owned_bytes_and_nodes_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl OwnedBytes and result mode NodesResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11087,7 +11087,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_ext
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_count_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_count_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl BufferedInput and result mode CountResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11099,7 +11099,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_lab
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_index_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_index_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl BufferedInput and result mode IndexResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11112,7 +11112,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_lab
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_nodes_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_nodes_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl BufferedInput and result mode NodesResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11131,7 +11131,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_lab
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_count_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_count_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl MmapInput and result mode CountResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11143,7 +11143,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_lab
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_index_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_index_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl MmapInput and result mode IndexResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11156,7 +11156,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_lab
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_nodes_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_nodes_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl MmapInput and result mode NodesResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11175,7 +11175,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_lab
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_count_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_count_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl OwnedBytes and result mode CountResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11187,7 +11187,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_lab
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_index_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_index_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl OwnedBytes and result mode IndexResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11200,7 +11200,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_lab
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_nodes_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_nodes_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl OwnedBytes and result mode NodesResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11219,7 +11219,7 @@ fn long_labels_to_search_with_head_skipping_compressed_with_query_select_the_lab
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_buffered_input_and_count_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extremely_long_label_with_buffered_input_and_count_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl BufferedInput and result mode CountResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11231,7 +11231,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_buffered_input_and_index_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extremely_long_label_with_buffered_input_and_index_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl BufferedInput and result mode IndexResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11244,7 +11244,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_buffered_input_and_nodes_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extremely_long_label_with_buffered_input_and_nodes_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl BufferedInput and result mode NodesResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11260,7 +11260,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_mmap_input_and_count_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extremely_long_label_with_mmap_input_and_count_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl MmapInput and result mode CountResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11272,7 +11272,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_mmap_input_and_index_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extremely_long_label_with_mmap_input_and_index_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl MmapInput and result mode IndexResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11285,7 +11285,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_mmap_input_and_nodes_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extremely_long_label_with_mmap_input_and_nodes_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl MmapInput and result mode NodesResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11301,7 +11301,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_owned_bytes_and_count_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extremely_long_label_with_owned_bytes_and_count_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl OwnedBytes and result mode CountResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11313,7 +11313,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_owned_bytes_and_index_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extremely_long_label_with_owned_bytes_and_index_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl OwnedBytes and result mode IndexResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11326,7 +11326,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long_label_with_owned_bytes_and_nodes_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extremely_long_label_with_owned_bytes_and_nodes_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249'] (select the extremely long label) with Input impl OwnedBytes and result mode NodesResult");
     let jsonpath_query = JsonPathQuery :: parse ("$..['very long label to search for, like, extremely long, so that the colon occurs really far away from the start of the needle match, which triggers some interesting behavior and might break the head skipping module like in #249']") ? ;
@@ -11342,7 +11342,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_extremely_long
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_count_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_count_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl BufferedInput and result mode CountResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11354,7 +11354,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_index_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_index_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl BufferedInput and result mode IndexResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11367,7 +11367,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_nodes_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_label_starting_exactly_at_block_boundary_with_buffered_input_and_nodes_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl BufferedInput and result mode NodesResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11383,7 +11383,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_count_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_count_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl MmapInput and result mode CountResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11395,7 +11395,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_index_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_index_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl MmapInput and result mode IndexResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11408,7 +11408,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_nodes_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_label_starting_exactly_at_block_boundary_with_mmap_input_and_nodes_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl MmapInput and result mode NodesResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11424,7 +11424,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_count_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_count_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl OwnedBytes and result mode CountResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11436,7 +11436,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_index_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_index_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl OwnedBytes and result mode IndexResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;
@@ -11449,7 +11449,7 @@ fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting
     Ok(())
 }
 #[test]
-fn long_labels_to_search_with_head_skipping_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_nodes_result_using_main_engine(
+fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_label_starting_exactly_at_block_boundary_with_owned_bytes_and_nodes_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document head_skip_long.toml running the query $..target (select the label starting exactly at block boundary) with Input impl OwnedBytes and result mode NodesResult");
     let jsonpath_query = JsonPathQuery::parse("$..target")?;

--- a/crates/rsonpath-lib/tests/query_parser_tests.rs
+++ b/crates/rsonpath-lib/tests/query_parser_tests.rs
@@ -149,7 +149,7 @@ fn indexed_wildcard_descendant_selector_nested() {
 
 #[test]
 fn escaped_single_quote_in_single_quote_member() {
-    let input = r#"['\'']"#;
+    let input = r"['\'']";
     let expected_query = JsonPathQueryBuilder::new().child(JsonString::new("'")).into();
 
     let result = JsonPathQuery::parse(input).expect("expected Ok");
@@ -227,15 +227,15 @@ mod transform_json_escape_sequences_tests {
 
     #[test_case("" => ""; "empty is unchanged")]
     #[test_case("abc" => "abc")]
-    #[test_case(r#"['\n']"# => r#"['\n']"#; "endline is unchanged")]
-    #[test_case(r#"['\t']"# => r#"['\t']"#; "tab is unchanged")]
-    #[test_case(r#"['\\']"# => r#"['\\']"#; "backslash is unchanged")]
-    #[test_case(r#"['\'']"# => r#"[''']"#; "single quote is unescaped")]
+    #[test_case(r"['\n']" => r"['\n']"; "endline is unchanged")]
+    #[test_case(r"['\t']" => r"['\t']"; "tab is unchanged")]
+    #[test_case(r"['\\']" => r"['\\']"; "backslash is unchanged")]
+    #[test_case(r"['\'']" => r#"[''']"#; "single quote is unescaped")]
     #[test_case(r#"['"']"# => r#"['\"']"#; "unescaped double quote is escaped")]
     #[test_case(r#"['\"']"# => r#"['\"']"#; "escaped double quote is unchanged")]
-    #[test_case(r#"['\/']"# => r#"['/']"#; "slash is unescaped")]
+    #[test_case(r"['\/']" => r#"['/']"#; "slash is unescaped")]
     #[test_case(r#"['\\"']"# => r#"['\\\"']"#; "escapes don't flow")]
-    #[test_case(r#"['\\'']"# => r#"['\\'']"#; "escapes don't flow2")]
+    #[test_case(r"['\\'']" => r"['\\'']"; "escapes don't flow2")]
     fn cases(input: &str) -> String {
         super::transform_json_escape_sequences(input.to_owned())
     }
@@ -282,7 +282,7 @@ mod proptests {
 
     // .* or [*]
     fn any_wildcard_child() -> impl Strategy<Value = Selector> {
-        r#"(\.\*|\[\*\])"#.prop_map(|x| Selector {
+        r"(\.\*|\[\*\])".prop_map(|x| Selector {
             string: x,
             tag: SelectorTag::WildcardChild,
         })
@@ -290,7 +290,7 @@ mod proptests {
 
     // ..* or ..[*]
     fn any_wildcard_descendant() -> impl Strategy<Value = Selector> {
-        r#"(\*|\[\*\])"#.prop_map(|x| Selector {
+        r"(\*|\[\*\])".prop_map(|x| Selector {
             string: format!("..{x}"),
             tag: SelectorTag::WildcardDescendant,
         })
@@ -327,7 +327,7 @@ mod proptests {
     }
 
     fn any_member() -> impl Strategy<Value = String> {
-        r#"([A-Za-z]|_|[^\u0000-\u007F])([A-Za-z0-9]|_|[^\u0000-\u007F])*"#
+        r"([A-Za-z]|_|[^\u0000-\u007F])([A-Za-z0-9]|_|[^\u0000-\u007F])*"
     }
 
     fn any_name() -> impl Strategy<Value = (String, String)> {

--- a/rsonpath.code-workspace
+++ b/rsonpath.code-workspace
@@ -82,6 +82,10 @@
 		"lldb.consoleMode": "commands",
 		"rust-analyzer.cargo.features": "all",
 		"rust-analyzer.linkedProjects": [
+			"./crates/rsonpath/Cargo.toml",
+			"./crates/rsonpath-lib/Cargo.toml",
+			"./crates/rsonpath-benchmarks/Cargo.toml",
+			"./crates/rsonpath-test/Cargo.toml",
 			"./crates/rsonpath-test-codegen/Cargo.toml"
 		]
 	}


### PR DESCRIPTION
## Short description

Track down, reproduce, and fix the bug in head skipping caused by one of two scenarios:

- "long" (longer than block size) keys being looked for by head skip;
- very specific scenario where the end of a subtree (the closing character) is exactly at the end of a block, the key being looked for is found in the next block, but whitespace cause the colon to occur in the next-next block (I know).

## Issue

Resolves: #249

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.