### PR TITLE
Patch Shell.nix to include rustfmt 

### DIFF
--- a/.github/workflows/test-codegen.yml
+++ b/.github/workflows/test-codegen.yml
@@ -14,6 +14,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   RSONPATH_ENABLE_TEST_CODEGEN: 1
+  CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG: "true"
   
 permissions:
   contents: read

--- a/shell.nix
+++ b/shell.nix
@@ -3,14 +3,8 @@ let
   stable = import (nixpkgs.fetchFromGitHub {
     owner = "NixOS";
     repo = "nixpkgs";
-    rev = "4ecab3273592f27479a583fb6d975d4aba3486fe";
-    sha256 = "btHN1czJ6rzteeCuE/PNrdssqYD2nIA4w48miQAFloM=";
-  }) {};
-  unstable = import (nixpkgs.fetchFromGitHub {
-    owner = "NixOS";
-    repo = "nixpkgs";
-    rev = "7403dd3fe24c2133089bdeaef593ed02c34fcdae";
-    sha256 = "vfHkC88PjYIpI1rsAOa7Cr6fXvPXxKM3tDvMPlgv0NM=";
+    rev = "57a0c58e728a28bc21eed85055eac9724a08f69a";
+    sha256 = "jZM9mIChS+tdrLt3/R6WnFNJCGcD8M/TpUgxrBgAN3M=";
   }) {};
 in stable.mkShell rec {
   buildInputs =
@@ -31,9 +25,8 @@ in stable.mkShell rec {
       rust-analyzer
       cargo-hack
       cargo-watch
-      rustfmt
-    ]) ++ (with unstable; [
       just
+      rustfmt
     ]);
 
   RUST_SRC_PATH = "${nixpkgs.rust.packages.stable.rustPlatform.rustLibSrc}";

--- a/shell.nix
+++ b/shell.nix
@@ -31,6 +31,7 @@ in stable.mkShell rec {
       rust-analyzer
       cargo-hack
       cargo-watch
+      rustfmt
     ]) ++ (with unstable; [
       just
     ]);


### PR DESCRIPTION
## Short description
This patch revises the project's shell.nix to include `rustfmt`.  I am still uncertain as to the root cause of the issue as `rustfmt` should have been installed anyways.  Nonetheless, GHA now passes.

I also took the opportunity to revise up the pinned repository version of the nixpkgs repository to help avoid unrelated issues in the future.

## Checklist

All of these should be ticked off before you submit the PR.

- [X] I ran `just verify` locally and it succeeded.
- [X] I have included justification for a minor change.
- [X] No functionality was changed.