### PR TITLE
Tweaks to the fuzzing CI

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 cd $SRC/rsonpath/fuzz
-cargo +nightly fuzz build -O --debug-assertions
+cargo +nightly fuzz build -O --debug-assertions -s $SANITIZER
 
 FUZZ_TARGET_OUTPUT_DIR=target/x86_64-unknown-linux-gnu/release
 

--- a/.github/workflows/clusterfuzzlite-batch.yml
+++ b/.github/workflows/clusterfuzzlite-batch.yml
@@ -1,6 +1,12 @@
 name: ClusterFuzzLite batch fuzzing
 on:
   workflow_dispatch:
+    inputs:
+      fuzz-seconds:
+        description: 'Total time to fuzz, in seconds'
+        required: true
+        default: 3600
+        type: number
   schedule:
     - cron: '0 3 * * *'
 
@@ -15,8 +21,7 @@ jobs:
       matrix:
         sanitizer:
         - address
-        - undefined
-        # - memory # doesn't seem to work, fails build
+        - memory
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
@@ -29,10 +34,10 @@ jobs:
       uses: google/clusterfuzzlite/actions/run_fuzzers@v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        fuzz-seconds: 3600
+        fuzz-seconds: ${{ inputs.fuzz-seconds }}
         mode: 'batch'
         sanitizer: ${{ matrix.sanitizer }}
         output-sarif: true
         storage-repo: https://${{ secrets.CLUSTERFUZZLITE_STORAGE_TOKEN }}@github.com/rsonpath/rsonpath-fuzz-storage.git
-        storage-repo-branch: main   # Optional. Defaults to "main"
-        storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
+        storage-repo-branch: main
+        storage-repo-branch-coverage: gh-pages

--- a/.github/workflows/clusterfuzzlite-batch.yml
+++ b/.github/workflows/clusterfuzzlite-batch.yml
@@ -25,13 +25,13 @@ jobs:
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         language: rust
         sanitizer: ${{ matrix.sanitizer }}
     - name: Run Fuzzers (${{ matrix.sanitizer }})
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         fuzz-seconds: ${{ inputs.fuzz-seconds }}

--- a/.github/workflows/clusterfuzzlite-cron.yml
+++ b/.github/workflows/clusterfuzzlite-cron.yml
@@ -1,6 +1,7 @@
 name: ClusterFuzzLite cron tasks
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 
@@ -13,12 +14,12 @@ jobs:
     steps:
     - name: Build Fuzzers
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         language: rust
     - name: Run Fuzzers
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         fuzz-seconds: 600
@@ -33,13 +34,13 @@ jobs:
     steps:
     - name: Build Fuzzers
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         language: rust
         sanitizer: coverage
     - name: Run Fuzzers
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         fuzz-seconds: 600

--- a/.github/workflows/clusterfuzzlite-pr.yml
+++ b/.github/workflows/clusterfuzzlite-pr.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         language: rust
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
         storage-repo-branch-coverage: gh-pages
     - name: Run Fuzzers (${{ matrix.sanitizer }})
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         fuzz-seconds: 600

--- a/.github/workflows/clusterfuzzlite-pr.yml
+++ b/.github/workflows/clusterfuzzlite-pr.yml
@@ -21,8 +21,7 @@ jobs:
       matrix:
         sanitizer:
         - address
-        # - undefined # requires coverage apriori, enable after first PR is merged
-        # - memory # doesn't seem to work, fails build
+        - memory
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### Features
+
+- Library exposes a new optional feature, `arbitrary`.
+  - When enabled, includes [`arbitrary`](https://lib.rs/crates/arbitrary)
+    as a dependency and provides an `Arbitrary` impl for `JsonPathQuery`,
+    `JsonString`, and `NonNegativeArrayIndex`.
+
+### Bug fixes
+
+- Fixed a bug when memmem acceleration would fail for empty keys.
+  - This was detected by fuzzing! The query `$..[""]` would panic
+    on certain inputs due to invalid indexing.
+- Fixed a panic when parsing invalid queries with wide UTF8 characters.
+  - This was detected by fuzzing! Parsing a query with invalid syntax
+    caused by a longer-than-byte UTF-8 character would panic when
+    the error handler tried to resume parsing from the next _byte_
+    instead of respecting char boundaries.
+- Fixed a panic caused by node results in invalid JSON documents.
+  - This was detected by fuzzing! Invalid JSON documents could
+    cause the NodeRecorder to panic if the apparent match span
+    was of length 1.
+
+### Reliability
+
+- Fuzzing integration with libfuzzer and ClusterFuzzLite.
+  - [`cargo-fuzz`](https://lib.rs/crates/cargo-fuzz) can be used
+    to fuzz the project with libfuzzer. Currently we have three fuzzing targets,
+    one for stressing the query parser, one for stressing the engine with arbitrary
+    bytes, and one stressing the engine with structure-aware queries and JSONs.
+  - Fuzzing is now enabled on every PR. Using ClusterFuzzLite
+    we will fuzz the project every day on a cron schedule
+    to establish a corpus.
+
 ## [0.8.0] - 2023-09-10
 
 ### Features


### PR DESCRIPTION
## Short description

- Passing the sanitizer didn't work, now the build.sh is fixed.
- Action versions are pinned by hash now.
- Added ability to run batch and cron on-demand, and parameterizing batch with time to fuzz.

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.