### PR TITLE
fix: panic when head-skipping to a single-byte key

### DIFF
--- a/.github/internal_templates/fuzz_failure.md
+++ b/.github/internal_templates/fuzz_failure.md
@@ -1,0 +1,22 @@
+---
+name: Batch fuzzing failure
+about: Batch fuzzing run failed and needs investigation
+title: ClusterFuzzLite Batch Fuzzing Failure {{ date | date('dddd, MMMM Do yyyy') }}
+labels: 'batch-fuzzer'
+assignees: 'V0ldek'
+
+---
+
+The action {{ action }} failed the fuzzer run.
+Run:  [{{ env.RUN_ID }}](https://github.com/V0ldek/rsonpath/actions/runs/{{ env.RUN_ID }})
+
+This issue is automatically generated and assigned to the maintainer.
+Use it to track the progress of the post-mortem.
+
+- [ ] Failure acknowledged.
+- [ ] Failure reproduced with the run's test case artifact.
+- [ ] Failure minimized using `cargo fuzz tmin`.
+- [ ] Follow-up bug issue created.
+
+Please, close this issue after the steps are completed and move any follow-up bugfix
+discussions in the resulting bug issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### Bug fixes
+
+- Fixed a bug when head-skipping to a single-byte key would panic.
+  - This was detected by fuzzing!
+  - The queries `$..["{"]` and `$..["["]` would panic
+    on inputs starting with the bytes `{"` or `["`, respectively.
+- Fixed a bug where disabling the `simd` feature would not actually
+  disable SIMD acceleration.
+
 ## [0.8.1] - 2023-09-20
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.
 - Fixed a bug where disabling the `simd` feature would not actually
   disable SIMD acceleration.
 
+### Reliability
+
+- Made the ClusterFuzzLite batch workflow automatically create an issue
+  on failure to make sure the maintainers are notified.
+
 ## [0.8.1] - 2023-09-20
 
 ### Features

--- a/Justfile
+++ b/Justfile
@@ -233,19 +233,15 @@ commit msg:
 
 # === HOOKS ===
 
-tmpdiff := if os() == "windows" {
-    `New-TemporaryFile`
-} else {
-    `mktemp -t pre-commit-hook-diff-XXXXXXXX.$$`
-}
-
 [private]
-hook-pre-commit: 
+hook-pre-commit:
+    #!/bin/sh
+    tmpdiff=$(mktemp -t pre-commit-hook-diff-XXXXXXXX.$$)
     just assert-benchmarks-committed
-    git diff --full-index --binary > {{tmpdiff}}
+    git diff --full-index --binary > $tmpdiff
     git stash -q --keep-index
     (just verify-fmt && just verify-check); \
-    git apply --whitespace=nowarn < {{tmpdiff}} && git stash drop -q; rm {{tmpdiff}}
+    git apply --whitespace=nowarn < $tmpdiff}} && git stash drop -q; rm $tmpdiff
 
 [private]
 @hook-post-checkout: checkout-benchmarks

--- a/crates/rsonpath-lib/src/classification/memmem/nosimd.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/nosimd.rs
@@ -58,7 +58,7 @@ where
         while let Some(block) = self.iter.next()? {
             let res = block.iter().copied().enumerate().find(|&(i, c)| {
                 let j = offset + i;
-                c == first_c && self.input.is_member_match(j - 1, j + label_size - 2, label)
+                c == first_c && j > 0 && self.input.is_member_match(j - 1, j + label_size - 2, label)
             });
 
             if let Some((res, _)) = res {

--- a/crates/rsonpath-lib/src/classification/memmem/shared/mask_32.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/shared/mask_32.rs
@@ -12,7 +12,7 @@ pub(crate) fn find_in_mask<I: Input>(
     let mut result = (previous_block | (first << 1)) & second;
     while result != 0 {
         let idx = result.trailing_zeros() as usize;
-        if input.is_member_match(offset + idx - 2, offset + idx + label_size - 3, label) {
+        if offset + idx > 1 && input.is_member_match(offset + idx - 2, offset + idx + label_size - 3, label) {
             return Some(offset + idx - 2);
         }
         result &= !(1 << idx);

--- a/crates/rsonpath-lib/src/classification/memmem/shared/mask_64.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/shared/mask_64.rs
@@ -13,7 +13,7 @@ pub(crate) fn find_in_mask<I: Input>(
     while result != 0 {
         let idx = result.trailing_zeros() as usize;
         debug!("{offset} + {idx} - 2 to {offset} + {idx} + {label_size} - 3");
-        if input.is_member_match(offset + idx - 2, offset + idx + label_size - 3, label) {
+        if offset + idx > 1 && input.is_member_match(offset + idx - 2, offset + idx + label_size - 3, label) {
             return Some(offset + idx - 2);
         }
         result &= !(1 << idx);

--- a/crates/rsonpath-lib/src/classification/simd.rs
+++ b/crates/rsonpath-lib/src/classification/simd.rs
@@ -343,7 +343,13 @@ pub fn configure() -> SimdConfiguration {
     }
 
     cfg_if! {
-        if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if #[cfg(not(feature = "simd"))]
+        {
+            let highest_simd = SimdTag::Nosimd;
+            let fast_quotes = false;
+            let fast_popcnt = false;
+        }
+        else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
             let highest_simd = if is_x86_feature_detected!("avx2") {
                 SimdTag::Avx2

--- a/crates/rsonpath-lib/tests/documents/toml/head_skip_for_curly.toml
+++ b/crates/rsonpath-lib/tests/documents/toml/head_skip_for_curly.toml
@@ -1,0 +1,26 @@
+# Define the JSON input for all query test cases.
+[input]
+# Short description of the input structure.
+description = "Object with an empty key."
+ # Set to true only if your specific test input is fully compressed (no extraneous whitespace).
+is_compressed = false
+
+# Inline JSON document.
+[input.source]
+json_string = '{"":null}'
+
+# Define queries to test on the input.
+[[queries]]
+ # Valid JSONPath query string.
+query = '$..["{"]'
+# Short descritpion of the query semantics.
+description = "descendant search for a key equal to the curly brace"
+
+[queries.results]
+# Number of expected matches.
+count = 0
+# Byte locations of spans of all matches, in order.
+spans = []
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = []

--- a/crates/rsonpath-lib/tests/documents/toml/head_skip_for_square.toml
+++ b/crates/rsonpath-lib/tests/documents/toml/head_skip_for_square.toml
@@ -1,0 +1,26 @@
+# Define the JSON input for all query test cases.
+[input]
+# Short description of the input structure.
+description = "List with an empty string."
+ # Set to true only if your specific test input is fully compressed (no extraneous whitespace).
+is_compressed = false
+
+# Inline JSON document.
+[input.source]
+json_string = '[""]'
+
+# Define queries to test on the input.
+[[queries]]
+ # Valid JSONPath query string.
+query = '$..["["]'
+# Short descritpion of the query semantics.
+description = "descendant search for a key equal to the square brace"
+
+[queries.results]
+# Number of expected matches.
+count = 0
+# Byte locations of spans of all matches, in order.
+spans = []
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = []

--- a/crates/rsonpath-lib/tests/end_to_end.rs
+++ b/crates/rsonpath-lib/tests/end_to_end.rs
@@ -1,4 +1,4 @@
-// a408cf20bda680a9005e3d0ce325e327
+// 9d6b9a42dabad16a52cf829a2df81b06
 use pretty_assertions::assert_eq;
 use rsonpath::engine::{main::MainEngine, Compiler, Engine};
 use rsonpath::input::*;
@@ -22762,6 +22762,552 @@ fn large_wikidata_dump_properties_with_query_path_to_p7103_claims_p31_references
     Ok(())
 }
 #[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_square.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the_square_brace_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_square.toml running the query $..[\"[\"] (descendant search for a key equal to the square brace) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"[\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_for_square.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
 fn list_with_mixed_atomic_integers_and_objects_compressed_with_query_select_all_elements_on_the_list_with_buffered_input_and_approx_span_result_using_main_engine(
 ) -> Result<(), Box<dyn Error>> {
     println ! ("on document compressed/heterogenous_list.toml running the query $.a.* (select all elements on the list) with Input impl BufferedInput and result mode ApproxSpanResult");
@@ -34452,6 +34998,552 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
     let utf8 = utf8.expect("valid utf8");
     let expected: Vec<&str> = vec!["44"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/head_skip_for_curly.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_curly_brace_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document head_skip_for_curly.toml running the query $..[\"{{\"] (descendant search for a key equal to the curly brace) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..[\"{\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/head_skip_for_curly.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
     assert_eq!(utf8, expected, "result != expected");
     Ok(())
 }

--- a/crates/rsonpath-test-codegen/src/gen.rs
+++ b/crates/rsonpath-test-codegen/src/gen.rs
@@ -33,7 +33,11 @@ pub(crate) fn generate_test_fns(files: &mut Files) -> Result<impl IntoIterator<I
                     );
                     let full_description = format!(
                         r#"on document {} running the query {} ({}) with Input impl {} and result mode {}"#,
-                        discovered_doc.name, query.query, query.description, input_type, result_type
+                        escape_format(&discovered_doc.name),
+                        escape_format(&query.query),
+                        escape_format(&query.description),
+                        escape_format(&input_type),
+                        escape_format(&result_type)
                     );
                     let body = generate_body(
                         &full_description,
@@ -335,4 +339,12 @@ impl Display for EngineTypeToTest {
             }
         )
     }
+}
+
+fn escape_format<D>(val: &D) -> impl Display
+where
+    D: Display,
+{
+    let s = val.to_string();
+    s.replace('{', "{{").replace('}', "}}")
 }

--- a/crates/rsonpath-test/Cargo.toml
+++ b/crates/rsonpath-test/Cargo.toml
@@ -17,4 +17,4 @@ publish = false
 [build-dependencies]
 eyre = "0.6.8"
 md5 = "0.7.0"
-rsonpath-test-codegen = { version = "0.8.0", path = "../rsonpath-test-codegen" }
+rsonpath-test-codegen = { version = "0.8.1", path = "../rsonpath-test-codegen" }

--- a/crates/rsonpath-test/README.md
+++ b/crates/rsonpath-test/README.md
@@ -1,8 +1,9 @@
 # Just codegen
 
-This crate is almost useless.
+This crate should be used only for the declarative TOML tests.
 
-It has no code in it except for the build script. The build script generates test cases for `rsonpath-lib`
+It has no code in it except for the build script and the generated script.
+The build script generates test cases for `rsonpath-lib` based on TOML files in `tests/documents`
 using `rsonpath-test-codegen`. This is needed for the following reasons:
 
 1. `rsonpath-test-codegen` cannot also have a `build.rs` script to generate the tests, since it would need to build-depend on itself;

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "static_assertions"


### PR DESCRIPTION
## Short description

This was detected by fuzzing! Searching for `{` or `[` with descendant would cause a panic
if the input started with the sequence
`{"` or `["`, respectively.

## Issue

Resolves: #81

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.