### PR TITLE
Root-only query handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,7 @@
         "memmap",
         "memmem",
         "Mmap",
+        "mmaps",
         "movemask",
         "ndash",
         "nondescendant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+### Performance
+
+- Improved handling of the root-only query `$`. ([#160](https://github.com/V0ldek/rsonpath/issues/160))
+  - Full nodes result when asking for root: 2 times throughput increase.
+  - Indices/count result when asking for root: basically unboundedly faster,
+    no longer looks at the entire document.
+
+### Documentation
+
+- Clarified that the `approximate_spans` guarantees.
+  - Now documentation mentions that the returned `MatchSpan`s can potentially
+    have their end indices farther than one would expect the input to logically end,
+    due to internal padding.
+
 ### Bug fixes
 
-- Fixed a bug when head-skipping to a single-byte key would panic.
+- Fixed handling of the root-only query `$` on atomic documents. ([#160](https://github.com/V0ldek/rsonpath/issues/160))
+  - Previously only object and array roots were supported.
+- Fixed a bug when head-skipping to a single-byte key would panic. ([#281](https://github.com/V0ldek/rsonpath/issues/281))
   - This was detected by fuzzing!
   - The queries `$..["{"]` and `$..["["]` would panic
     on inputs starting with the bytes `{"` or `["`, respectively.

--- a/crates/rsonpath-lib/src/engine.rs
+++ b/crates/rsonpath-lib/src/engine.rs
@@ -8,6 +8,7 @@ mod head_skipping;
 pub mod main;
 mod tail_skipping;
 pub use main::MainEngine as RsonpathEngine;
+mod empty_query;
 
 use self::error::EngineError;
 use crate::{
@@ -57,7 +58,10 @@ pub trait Engine {
     /// Find the approximate spans of matches on the given [`Input`] and write them to the [`Sink`].
     ///
     /// "Approximate" means that the ends of spans are not guaranteed to be located exactly at the end of a match,
-    /// but may include trailing whitespace. It is guaranteed that:
+    /// but may include trailing whitespace. **Importantly**, it may be beyond the rigidly-defined length of the
+    /// input, as the engine is allowed to pad the input with whitespace to help with processing. For the purposes
+    /// of this API, it is assumed that every character after the logical end of the input is a whitespace character.
+    /// With that in mind, it is guaranteed that:
     /// 1. the span start is exact;
     /// 2. the span encompasses the entire matched value;
     /// 3. the only characters included after the value are JSON whitespace characters:

--- a/crates/rsonpath-lib/src/engine/empty_query.rs
+++ b/crates/rsonpath-lib/src/engine/empty_query.rs
@@ -1,0 +1,118 @@
+//! Special case handlers for the empty query $.
+//!
+//! The main engine is built with a path automaton in mind, and for simplicity
+//! we assume the root opening was already read. This makes it incompatible with
+//! an empty query. Instead of rewriting the engine we provide fast-path implementations
+//! here.
+use crate::{
+    engine::{error::EngineError, Input},
+    is_json_whitespace,
+    result::{empty::EmptyRecorder, Match, MatchCount, MatchIndex, MatchSpan, Sink},
+    FallibleIterator, BLOCK_SIZE,
+};
+
+/// Count for an empty query &ndash; determine if the root exists.
+pub(super) fn count<I>(input: &I) -> Result<MatchCount, EngineError>
+where
+    I: Input,
+{
+    // Assuming a correct JSON, there is either one root if any non-whitespace character
+    // occurs in the document, or the document is empty.
+    if input.seek_non_whitespace_forward(0)?.is_some() {
+        Ok(1)
+    } else {
+        Ok(0)
+    }
+}
+
+/// Index for an empty query &ndash; determine the first index of the root.
+pub(super) fn index<I, S>(input: &I, sink: &mut S) -> Result<(), EngineError>
+where
+    I: Input,
+    S: Sink<MatchIndex>,
+{
+    // Assuming a correct JSON, the root starts at the first non-whitespace character, if any.
+    if let Some((first_idx, _)) = input.seek_non_whitespace_forward(0)? {
+        sink.add_match(first_idx)
+            .map_err(|err| EngineError::SinkError(Box::new(err)))?;
+    }
+
+    Ok(())
+}
+
+/// Approximate span for an empty query &ndash; determine the first index and the length of the root.
+pub(super) fn approx_span<I, S>(input: &I, sink: &mut S) -> Result<(), EngineError>
+where
+    I: Input,
+    S: Sink<MatchSpan>,
+{
+    // The root spans the entire document, by definition, with the exception of whitespace.
+    // We need to find the start index exactly, and then can return the length of the rest as the approximate
+    // length of the root.
+    //
+    // Some input know their lengths: bytes already in memory, file mmaps, etc.
+    // A BufferedInput over an arbitrary Read stream cannot know its length, so we actually
+    // need to iterate until the end and count the bytes.
+    if let Some((first_idx, _)) = input.seek_non_whitespace_forward(0)? {
+        let end_idx = match input.len_hint() {
+            Some(end_idx) => end_idx, // Known length, just take it.
+            None => {
+                // Unknown length, iterate and count.
+                let mut iter = input.iter_blocks::<_, BLOCK_SIZE>(&EmptyRecorder);
+                let mut end_idx = 0;
+
+                while (iter.next()?).is_some() {
+                    end_idx += BLOCK_SIZE;
+                }
+
+                end_idx
+            }
+        };
+
+        sink.add_match(MatchSpan::from_indices(first_idx, end_idx))
+            .map_err(|err| EngineError::SinkError(Box::new(err)))?;
+    }
+
+    Ok(())
+}
+
+/// Match for an empty query &ndash; copy the entire document, trimming whitespace.
+pub(super) fn match_<I, S>(input: &I, sink: &mut S) -> Result<(), EngineError>
+where
+    I: Input,
+    S: Sink<Match>,
+{
+    // For a full match we need to copy the entire input starting from first non-whitespace,
+    // and then trim the whitespace from the end. This might be slow if the document is excessively
+    // padded with whitespace at start and/or end, but that's a pathological case.
+    let mut iter = input.iter_blocks::<_, BLOCK_SIZE>(&EmptyRecorder);
+    let mut res: Vec<u8> = vec![];
+    let mut first_significant_idx = None;
+
+    while let Some(block) = iter.next()? {
+        if first_significant_idx.is_none() {
+            // Start of the root not found yet, look for it.
+            first_significant_idx = block.iter().position(|&x| !is_json_whitespace(x));
+
+            if let Some(first_idx) = first_significant_idx {
+                // Start of the root found in this block, copy the relevant part.
+                res.extend(&block[first_idx..]);
+            }
+        } else {
+            // Start of the root was already found, now we are copying everything.
+            res.extend(&*block);
+        }
+    }
+
+    if let Some(start) = first_significant_idx {
+        // Trim whitespace if we have a result.
+        while !res.is_empty() && is_json_whitespace(res[res.len() - 1]) {
+            res.pop();
+        }
+
+        sink.add_match(Match::from_start_and_bytes(start, res))
+            .map_err(|err| EngineError::SinkError(Box::new(err)))?;
+    }
+
+    Ok(())
+}

--- a/crates/rsonpath-lib/src/input.rs
+++ b/crates/rsonpath-lib/src/input.rs
@@ -62,6 +62,17 @@ pub trait Input: Sized {
     where
         Self: 'i;
 
+    /// Return the length of the entire input, if known.
+    ///
+    /// This is meant to be used merely as a hint.
+    /// There are [`Input`] implementations that may not be able to know the entire
+    /// length a priori, and they should return [`None`].
+    #[inline(always)]
+    #[must_use]
+    fn len_hint(&self) -> Option<usize> {
+        None
+    }
+
     /// Iterate over blocks of size `N` of the input.
     /// `N` has to be a power of two larger than 1.
     #[must_use]
@@ -293,11 +304,11 @@ mod tests {
         use pretty_assertions::assert_eq;
 
         #[test]
-        fn on_empty_bytes_is_all_zero() {
+        fn on_empty_bytes_is_all_whitespace() {
             let result = in_slice::pad_last_block(&[]);
 
             assert_eq!(result.absolute_start, 0);
-            assert_eq!(result.bytes, [0; MAX_BLOCK_SIZE]);
+            assert_eq!(result.bytes, [b' '; MAX_BLOCK_SIZE]);
         }
 
         #[test]
@@ -308,17 +319,17 @@ mod tests {
 
             assert_eq!(result.absolute_start, 0);
             assert_eq!(&result.bytes[0..11], bytes);
-            assert_eq!(&result.bytes[11..], [0; MAX_BLOCK_SIZE - 11]);
+            assert_eq!(&result.bytes[11..], [b' '; MAX_BLOCK_SIZE - 11]);
         }
 
         #[test]
-        fn on_bytes_equal_to_full_block_gives_all_zero() {
+        fn on_bytes_equal_to_full_block_gives_all_whitespace() {
             let bytes = [42; MAX_BLOCK_SIZE];
 
             let result = in_slice::pad_last_block(&bytes);
 
             assert_eq!(result.absolute_start, MAX_BLOCK_SIZE);
-            assert_eq!(result.bytes, [0; MAX_BLOCK_SIZE]);
+            assert_eq!(result.bytes, [b' '; MAX_BLOCK_SIZE]);
         }
 
         #[test]
@@ -330,7 +341,7 @@ mod tests {
 
             assert_eq!(result.absolute_start, 2 * MAX_BLOCK_SIZE);
             assert_eq!(result.bytes[0..77], [69; 77]);
-            assert_eq!(result.bytes[77..], [0; MAX_BLOCK_SIZE - 77]);
+            assert_eq!(result.bytes[77..], [b' '; MAX_BLOCK_SIZE - 77]);
         }
     }
 

--- a/crates/rsonpath-lib/src/input.rs
+++ b/crates/rsonpath-lib/src/input.rs
@@ -169,7 +169,7 @@ pub(super) mod in_slice {
 
     #[inline]
     pub(super) fn pad_last_block(bytes: &[u8]) -> LastBlock {
-        let mut last_block_buf = [0; MAX_BLOCK_SIZE];
+        let mut last_block_buf = [b' '; MAX_BLOCK_SIZE];
         let last_block_start = (bytes.len() / MAX_BLOCK_SIZE) * MAX_BLOCK_SIZE;
         let last_block_slice = &bytes[last_block_start..];
 

--- a/crates/rsonpath-lib/src/input/borrowed.rs
+++ b/crates/rsonpath-lib/src/input/borrowed.rs
@@ -96,6 +96,11 @@ impl<'a> Input for BorrowedBytes<'a> {
     type Block<'b, const N: usize> = &'b [u8] where Self: 'b;
 
     #[inline(always)]
+    fn len_hint(&self) -> Option<usize> {
+        Some((self.bytes.len() / MAX_BLOCK_SIZE + 1) * MAX_BLOCK_SIZE)
+    }
+
+    #[inline(always)]
     fn iter_blocks<'b, 'r, R, const N: usize>(&'b self, recorder: &'r R) -> Self::BlockIterator<'b, 'r, N, R>
     where
         R: InputRecorder<&'b [u8]>,

--- a/crates/rsonpath-lib/src/input/buffered.rs
+++ b/crates/rsonpath-lib/src/input/buffered.rs
@@ -74,7 +74,7 @@ impl<R: Read> InternalBuffer<R> {
         }
 
         if self.chunk_idx == self.bytes.len() {
-            self.bytes.push(BufferedChunk([0; BUF_SIZE]));
+            self.bytes.push(BufferedChunk([b' '; BUF_SIZE]));
         }
 
         let buf = &mut self.bytes[self.chunk_idx].0;

--- a/crates/rsonpath-lib/src/input/mmap.rs
+++ b/crates/rsonpath-lib/src/input/mmap.rs
@@ -15,7 +15,7 @@
 //! by an order of magnitude to execute the query on a memory map than it is to simply read the
 //! file into main memory.
 
-use super::{borrowed::BorrowedBytesBlockIterator, error::InputError, in_slice, Input, LastBlock};
+use super::{borrowed::BorrowedBytesBlockIterator, error::InputError, in_slice, Input, LastBlock, MAX_BLOCK_SIZE};
 use crate::{query::JsonString, result::InputRecorder};
 use memmap2::{Mmap, MmapAsRawDesc};
 
@@ -54,6 +54,11 @@ impl Input for MmapInput {
         R: InputRecorder<&'a [u8]> + 'r;
 
     type Block<'a, const N: usize> = &'a [u8];
+
+    #[inline(always)]
+    fn len_hint(&self) -> Option<usize> {
+        Some((self.mmap.len() / MAX_BLOCK_SIZE + 1) * MAX_BLOCK_SIZE)
+    }
 
     #[inline(always)]
     fn iter_blocks<'a, 'r, R, const N: usize>(&'a self, recorder: &'r R) -> Self::BlockIterator<'a, 'r, N, R>

--- a/crates/rsonpath-lib/src/input/owned.rs
+++ b/crates/rsonpath-lib/src/input/owned.rs
@@ -226,6 +226,11 @@ impl Input for OwnedBytes {
     type Block<'a, const N: usize> = &'a [u8];
 
     #[inline(always)]
+    fn len_hint(&self) -> Option<usize> {
+        Some((self.len / MAX_BLOCK_SIZE + 1) * MAX_BLOCK_SIZE)
+    }
+
+    #[inline(always)]
     fn iter_blocks<'a, 'r, R, const N: usize>(&'a self, recorder: &'r R) -> Self::BlockIterator<'a, 'r, N, R>
     where
         R: InputRecorder<&'a [u8]>,

--- a/crates/rsonpath-lib/src/input/owned.rs
+++ b/crates/rsonpath-lib/src/input/owned.rs
@@ -116,7 +116,7 @@ impl OwnedBytes {
         // SAFETY:
         unsafe {
             ptr::copy_nonoverlapping(slice.as_ptr(), ptr.as_ptr(), slice.len());
-            ptr::write_bytes(ptr.as_ptr().add(slice.len()), 0, pad);
+            ptr::write_bytes(ptr.as_ptr().add(slice.len()), b' ', pad);
         };
 
         // SAFETY: At this point we allocated and initialized exactly `size` bytes.

--- a/crates/rsonpath-lib/src/lib.rs
+++ b/crates/rsonpath-lib/src/lib.rs
@@ -346,3 +346,9 @@ impl<F: FallibleIterator> Iterator for FallibleIntoIter<F> {
         }
     }
 }
+
+#[inline(always)]
+#[must_use]
+pub(crate) fn is_json_whitespace(x: u8) -> bool {
+    x == b' ' || x == b'\t' || x == b'\n' || x == b'\r'
+}

--- a/crates/rsonpath-lib/src/result.rs
+++ b/crates/rsonpath-lib/src/result.rs
@@ -41,6 +41,19 @@ pub struct Match {
 }
 
 impl MatchSpan {
+    pub(crate) fn from_indices(start_idx: usize, end_idx: usize) -> Self {
+        assert!(
+            start_idx <= end_idx,
+            "start of span {} is greater than end {}",
+            start_idx,
+            end_idx
+        );
+        Self {
+            start_idx,
+            len: end_idx - start_idx,
+        }
+    }
+
     /// Returns the starting index of the match.
     #[inline(always)]
     #[must_use]
@@ -65,6 +78,10 @@ impl MatchSpan {
 }
 
 impl Match {
+    pub(crate) fn from_start_and_bytes(span_start: usize, bytes: Vec<u8>) -> Self {
+        Self { bytes, span_start }
+    }
+
     /// Returns the JSON contents of the match.
     #[inline(always)]
     #[must_use]

--- a/crates/rsonpath-lib/tests/documents/toml/atomic_root_empty_string.toml
+++ b/crates/rsonpath-lib/tests/documents/toml/atomic_root_empty_string.toml
@@ -1,0 +1,44 @@
+# Define the JSON input for all query test cases.
+[input]
+# Short description of the input structure.
+description = "The root is an empty string."
+ # Set to true only if your specific test input is fully compressed (no extraneous whitespace).
+is_compressed = true
+
+# Inline JSON document.
+[input.source]
+json_string = '""'
+
+# Define queries to test on the input.
+[[queries]]
+ # Valid JSONPath query string.
+query = "$"
+# Short descritpion of the query semantics.
+description = "select the root"
+
+[queries.results]
+# Number of expected matches.
+count = 1
+# Byte locations of spans of all matches, in order.
+spans = [[0, 2]]
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = ['""']
+
+[[queries]]
+query = "$..*"
+description = "select all subdocuments of which there are none"
+
+[queries.results]
+count = 0
+spans = []
+nodes = []
+
+[[queries]]
+query = '$[""]'
+description = "look for an empty key which should not match the root"
+
+[queries.results]
+count = 0
+spans = []
+nodes = []

--- a/crates/rsonpath-lib/tests/documents/toml/atomic_root_false.toml
+++ b/crates/rsonpath-lib/tests/documents/toml/atomic_root_false.toml
@@ -1,0 +1,35 @@
+# Define the JSON input for all query test cases.
+[input]
+# Short description of the input structure.
+description = "The root is the atomic value false."
+ # Set to true only if your specific test input is fully compressed (no extraneous whitespace).
+is_compressed = true
+
+# Inline JSON document.
+[input.source]
+json_string = "false"
+
+# Define queries to test on the input.
+[[queries]]
+ # Valid JSONPath query string.
+query = "$"
+# Short descritpion of the query semantics.
+description = "select the root"
+
+[queries.results]
+# Number of expected matches.
+count = 1
+# Byte locations of spans of all matches, in order.
+spans = [[0, 5]]
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = ["false"]
+
+[[queries]]
+query = "$..*"
+description = "select all subdocuments of which there are none"
+
+[queries.results]
+count = 0
+spans = []
+nodes = []

--- a/crates/rsonpath-lib/tests/documents/toml/atomic_root_nonempty_string.toml
+++ b/crates/rsonpath-lib/tests/documents/toml/atomic_root_nonempty_string.toml
@@ -1,0 +1,44 @@
+# Define the JSON input for all query test cases.
+[input]
+# Short description of the input structure.
+description = "The root is a non-empty string."
+ # Set to true only if your specific test input is fully compressed (no extraneous whitespace).
+is_compressed = true
+
+# Inline JSON document.
+[input.source]
+json_string = '"some string"'
+
+# Define queries to test on the input.
+[[queries]]
+ # Valid JSONPath query string.
+query = "$"
+# Short descritpion of the query semantics.
+description = "select the root"
+
+[queries.results]
+# Number of expected matches.
+count = 1
+# Byte locations of spans of all matches, in order.
+spans = [[0, 13]]
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = ['"some string"']
+
+[[queries]]
+query = "$..*"
+description = "select all subdocuments of which there are none"
+
+[queries.results]
+count = 0
+spans = []
+nodes = []
+
+[[queries]]
+query = '$["some string"]'
+description = "look for the key equal to the root value, which should not match"
+
+[queries.results]
+count = 0
+spans = []
+nodes = []

--- a/crates/rsonpath-lib/tests/documents/toml/atomic_root_null.toml
+++ b/crates/rsonpath-lib/tests/documents/toml/atomic_root_null.toml
@@ -1,0 +1,35 @@
+# Define the JSON input for all query test cases.
+[input]
+# Short description of the input structure.
+description = "The root is the atomic value null."
+ # Set to true only if your specific test input is fully compressed (no extraneous whitespace).
+is_compressed = true
+
+# Inline JSON document.
+[input.source]
+json_string = "null"
+
+# Define queries to test on the input.
+[[queries]]
+ # Valid JSONPath query string.
+query = "$"
+# Short descritpion of the query semantics.
+description = "select the root"
+
+[queries.results]
+# Number of expected matches.
+count = 1
+# Byte locations of spans of all matches, in order.
+spans = [[0, 4]]
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = ["null"]
+
+[[queries]]
+query = "$..*"
+description = "select all subdocuments of which there are none"
+
+[queries.results]
+count = 0
+spans = []
+nodes = []

--- a/crates/rsonpath-lib/tests/documents/toml/atomic_root_number_float.toml
+++ b/crates/rsonpath-lib/tests/documents/toml/atomic_root_number_float.toml
@@ -1,0 +1,35 @@
+# Define the JSON input for all query test cases.
+[input]
+# Short description of the input structure.
+description = "The root is an atomic floating-point number."
+ # Set to true only if your specific test input is fully compressed (no extraneous whitespace).
+is_compressed = true
+
+# Inline JSON document.
+[input.source]
+json_string = "123456789.1337"
+
+# Define queries to test on the input.
+[[queries]]
+ # Valid JSONPath query string.
+query = "$"
+# Short descritpion of the query semantics.
+description = "select the root"
+
+[queries.results]
+# Number of expected matches.
+count = 1
+# Byte locations of spans of all matches, in order.
+spans = [[0, 14]]
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = ["123456789.1337"]
+
+[[queries]]
+query = "$..*"
+description = "select all subdocuments of which there are none"
+
+[queries.results]
+count = 0
+spans = []
+nodes = []

--- a/crates/rsonpath-lib/tests/documents/toml/atomic_root_number_integer.toml
+++ b/crates/rsonpath-lib/tests/documents/toml/atomic_root_number_integer.toml
@@ -1,0 +1,35 @@
+# Define the JSON input for all query test cases.
+[input]
+# Short description of the input structure.
+description = "The root is an atomic integral number."
+ # Set to true only if your specific test input is fully compressed (no extraneous whitespace).
+is_compressed = true
+
+# Inline JSON document.
+[input.source]
+json_string = "123456789"
+
+# Define queries to test on the input.
+[[queries]]
+ # Valid JSONPath query string.
+query = "$"
+# Short descritpion of the query semantics.
+description = "select the root"
+
+[queries.results]
+# Number of expected matches.
+count = 1
+# Byte locations of spans of all matches, in order.
+spans = [[0, 9]]
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = ["123456789"]
+
+[[queries]]
+query = "$..*"
+description = "select all subdocuments of which there are none"
+
+[queries.results]
+count = 0
+spans = []
+nodes = []

--- a/crates/rsonpath-lib/tests/documents/toml/atomic_root_number_scientific_notation.toml
+++ b/crates/rsonpath-lib/tests/documents/toml/atomic_root_number_scientific_notation.toml
@@ -1,0 +1,35 @@
+# Define the JSON input for all query test cases.
+[input]
+# Short description of the input structure.
+description = "The root is an atomic floating-point number in scientific notation."
+ # Set to true only if your specific test input is fully compressed (no extraneous whitespace).
+is_compressed = true
+
+# Inline JSON document.
+[input.source]
+json_string = "123456789.1337e-25"
+
+# Define queries to test on the input.
+[[queries]]
+ # Valid JSONPath query string.
+query = "$"
+# Short descritpion of the query semantics.
+description = "select the root"
+
+[queries.results]
+# Number of expected matches.
+count = 1
+# Byte locations of spans of all matches, in order.
+spans = [[0, 18]]
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = ["123456789.1337e-25"]
+
+[[queries]]
+query = "$..*"
+description = "select all subdocuments of which there are none"
+
+[queries.results]
+count = 0
+spans = []
+nodes = []

--- a/crates/rsonpath-lib/tests/documents/toml/atomic_root_true.toml
+++ b/crates/rsonpath-lib/tests/documents/toml/atomic_root_true.toml
@@ -1,0 +1,35 @@
+# Define the JSON input for all query test cases.
+[input]
+# Short description of the input structure.
+description = "The root is the atomic value true."
+ # Set to true only if your specific test input is fully compressed (no extraneous whitespace).
+is_compressed = true
+
+# Inline JSON document.
+[input.source]
+json_string = "true"
+
+# Define queries to test on the input.
+[[queries]]
+ # Valid JSONPath query string.
+query = "$"
+# Short descritpion of the query semantics.
+description = "select the root"
+
+[queries.results]
+# Number of expected matches.
+count = 1
+# Byte locations of spans of all matches, in order.
+spans = [[0, 4]]
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = ["true"]
+
+[[queries]]
+query = "$..*"
+description = "select all subdocuments of which there are none"
+
+[queries.results]
+count = 0
+spans = []
+nodes = []

--- a/crates/rsonpath-lib/tests/end_to_end.rs
+++ b/crates/rsonpath-lib/tests/end_to_end.rs
@@ -1,4 +1,4 @@
-// 47bc13aeee0aa37cf8f6478ddf2fb213
+// bf9bed65f899df486beb41882a8da840
 use pretty_assertions::assert_eq;
 use rsonpath::engine::{main::MainEngine, Compiler, Engine};
 use rsonpath::input::*;
@@ -9800,7 +9800,7 @@ fn empty_array_root_compressed_with_query_select_the_root_empty_query_with_buffe
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -9891,7 +9891,7 @@ fn empty_array_root_compressed_with_query_select_the_root_empty_query_with_mmap_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -9982,7 +9982,7 @@ fn empty_array_root_compressed_with_query_select_the_root_empty_query_with_owned
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10073,7 +10073,7 @@ fn empty_array_root_compressed_with_query_select_the_root_with_buffered_input_an
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10164,7 +10164,7 @@ fn empty_array_root_compressed_with_query_select_the_root_with_mmap_input_and_ap
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10255,7 +10255,7 @@ fn empty_array_root_compressed_with_query_select_the_root_with_owned_bytes_and_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11165,7 +11165,7 @@ fn empty_array_root_with_query_select_the_root_empty_query_with_buffered_input_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 3usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11256,7 +11256,7 @@ fn empty_array_root_with_query_select_the_root_empty_query_with_mmap_input_and_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 3usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11347,7 +11347,7 @@ fn empty_array_root_with_query_select_the_root_empty_query_with_owned_bytes_and_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 3usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11438,7 +11438,7 @@ fn empty_array_root_with_query_select_the_root_with_buffered_input_and_approx_sp
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 3usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11529,7 +11529,7 @@ fn empty_array_root_with_query_select_the_root_with_mmap_input_and_approx_span_r
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 3usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11620,7 +11620,7 @@ fn empty_array_root_with_query_select_the_root_with_owned_bytes_and_approx_span_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 3usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14714,7 +14714,7 @@ fn empty_object_root_compressed_with_query_select_the_root_empty_query_with_buff
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14805,7 +14805,7 @@ fn empty_object_root_compressed_with_query_select_the_root_empty_query_with_mmap
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14896,7 +14896,7 @@ fn empty_object_root_compressed_with_query_select_the_root_empty_query_with_owne
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14987,7 +14987,7 @@ fn empty_object_root_compressed_with_query_select_the_root_with_buffered_input_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -15078,7 +15078,7 @@ fn empty_object_root_compressed_with_query_select_the_root_with_mmap_input_and_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -15169,7 +15169,7 @@ fn empty_object_root_compressed_with_query_select_the_root_with_owned_bytes_and_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16079,7 +16079,7 @@ fn empty_object_root_with_query_select_the_root_empty_query_with_buffered_input_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 3usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16170,7 +16170,7 @@ fn empty_object_root_with_query_select_the_root_empty_query_with_mmap_input_and_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 3usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16261,7 +16261,7 @@ fn empty_object_root_with_query_select_the_root_empty_query_with_owned_bytes_and
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 3usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16352,7 +16352,7 @@ fn empty_object_root_with_query_select_the_root_with_buffered_input_and_approx_s
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 3usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16443,7 +16443,7 @@ fn empty_object_root_with_query_select_the_root_with_mmap_input_and_approx_span_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 3usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16534,7 +16534,7 @@ fn empty_object_root_with_query_select_the_root_with_owned_bytes_and_approx_span
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 3usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -50965,7 +50965,7 @@ fn the_root_is_a_non_empty_string_with_query_select_the_root_with_buffered_input
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51056,7 +51056,7 @@ fn the_root_is_a_non_empty_string_with_query_select_the_root_with_mmap_input_and
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51148,7 +51148,7 @@ fn the_root_is_a_non_empty_string_with_query_select_the_root_with_owned_bytes_an
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51537,7 +51537,7 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 18usize, 18usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 18usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51633,7 +51633,7 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 18usize, 18usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 18usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51730,7 +51730,7 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 18usize, 18usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 18usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52102,7 +52102,7 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_b
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 14usize, 14usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 14usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52193,7 +52193,7 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_m
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 14usize, 14usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 14usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52284,7 +52284,7 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_o
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 14usize, 14usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 14usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52653,7 +52653,7 @@ fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_buffere
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 9usize, 9usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 9usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52744,7 +52744,7 @@ fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_mmap_in
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 9usize, 9usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 9usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52836,7 +52836,7 @@ fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_owned_b
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 9usize, 9usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 9usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53477,7 +53477,7 @@ fn the_root_is_an_empty_string_with_query_select_the_root_with_buffered_input_an
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53568,7 +53568,7 @@ fn the_root_is_an_empty_string_with_query_select_the_root_with_mmap_input_and_ap
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53659,7 +53659,7 @@ fn the_root_is_an_empty_string_with_query_select_the_root_with_owned_bytes_and_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54023,7 +54023,7 @@ fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_buffered_i
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 5usize, 5usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 5usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54114,7 +54114,7 @@ fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_mmap_input
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 5usize, 5usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 5usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54205,7 +54205,7 @@ fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_owned_byte
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 5usize, 5usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 5usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54569,7 +54569,7 @@ fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_buffered_in
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 4usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54660,7 +54660,7 @@ fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_mmap_input_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 4usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54751,7 +54751,7 @@ fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_owned_bytes
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 4usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -55115,7 +55115,7 @@ fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_buffered_in
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 4usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -55206,7 +55206,7 @@ fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_mmap_input_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 4usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -55297,7 +55297,7 @@ fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_owned_bytes
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 4usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -59321,7 +59321,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -59412,7 +59412,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -59503,7 +59503,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -60425,7 +60425,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 25usize, 26usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 25usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -60516,7 +60516,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 25usize, 26usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 25usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -60607,7 +60607,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 25usize, 26usize)];
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 25usize, 18446744073709551615usize)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];

--- a/crates/rsonpath-lib/tests/end_to_end.rs
+++ b/crates/rsonpath-lib/tests/end_to_end.rs
@@ -1,4 +1,4 @@
-// 9d6b9a42dabad16a52cf829a2df81b06
+// 47bc13aeee0aa37cf8f6478ddf2fb213
 use pretty_assertions::assert_eq;
 use rsonpath::engine::{main::MainEngine, Compiler, Engine};
 use rsonpath::input::*;
@@ -50395,6 +50395,4985 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_with_q
     let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
     let utf8 = utf8.expect("valid utf8");
     let expected: Vec<&str> = vec!["\"iPhone\"", "\"home\"", "\"iPhone\"", "\"home\""];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_value_which_should_not_match_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $[\"some string\"] (look for the key equal to the root value, which should not match) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"some string\"]")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 13usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 13usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["\"some string\""];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 13usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 13usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["\"some string\""];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 13usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 13usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_a_non_empty_string_with_query_select_the_root_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_nonempty_string.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_nonempty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["\"some string\""];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string(
+        "../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json",
+    )?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string(
+        "../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json",
+    )?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string(
+        "../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json",
+    )?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string(
+        "../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json",
+    )?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string(
+        "../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json",
+    )?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 18usize, 18usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 18usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["123456789.1337e-25"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 18usize, 18usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 18usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file =
+        fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["123456789.1337e-25"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string(
+        "../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json",
+    )?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 18usize, 18usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string(
+        "../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json",
+    )?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string(
+        "../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json",
+    )?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string(
+        "../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json",
+    )?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 18usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query_select_the_root_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_scientific_notation.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string(
+        "../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_scientific_notation.json",
+    )?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["123456789.1337e-25"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 14usize, 14usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 14usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["123456789.1337"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 14usize, 14usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 14usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["123456789.1337"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 14usize, 14usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 14usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_float.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_float.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["123456789.1337"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 9usize, 9usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 9usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["123456789"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 9usize, 9usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 9usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["123456789"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 9usize, 9usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 9usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_number_integer.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json =
+        fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_number_integer.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["123456789"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not_match_the_root_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $[\"\"] (look for an empty key which should not match the root) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$[\"\"]")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 2usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["\"\""];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 2usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["\"\""];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 2usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 2usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_an_empty_string_with_query_select_the_root_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_empty_string.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_empty_string.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["\"\""];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 5usize, 5usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 5usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["false"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 5usize, 5usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 5usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["false"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 5usize, 5usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 5usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_false.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_false.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["false"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 4usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 4usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["null"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 4usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 4usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["null"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 4usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 4usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_null.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_null.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["null"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 0u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which_there_are_none_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $..* (select all subdocuments of which there are none) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$..*")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec![];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_buffered_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl BufferedInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 4usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_buffered_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl BufferedInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_buffered_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl BufferedInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_buffered_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 4usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_buffered_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl BufferedInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = BufferedInput::new(json_file);
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["true"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_mmap_input_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl MmapInput and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 4usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_mmap_input_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl MmapInput and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_mmap_input_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl MmapInput and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_mmap_input_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 4usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_mmap_input_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl MmapInput and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let json_file = fs::File::open("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = unsafe { MmapInput::map_file(&json_file)? };
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["true"];
+    assert_eq!(utf8, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_owned_bytes_and_approx_span_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl OwnedBytes and result mode ApproxSpanResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.approximate_spans(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
+    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 4usize)];
+    assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
+    for i in 0..tups.len() {
+        let upper_bound = expected[i];
+        let actual = tups[i];
+        assert_eq!(actual.0, upper_bound.0, "result start_idx() != expected start_idx()");
+        assert!(
+            actual.1 >= upper_bound.1,
+            "result end_idx() < expected end_lower_bound ({} < {})",
+            actual.1,
+            upper_bound.1
+        );
+        assert!(
+            actual.1 <= upper_bound.2,
+            "result end_idx() > expected end_upper_bound ({} > {}",
+            actual.1,
+            upper_bound.2
+        );
+    }
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_owned_bytes_and_count_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl OwnedBytes and result mode CountResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let result = engine.count(&input)?;
+    assert_eq!(result, 1u64, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_owned_bytes_and_index_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl OwnedBytes and result mode IndexResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.indices(&input, &mut result)?;
+    assert_eq!(result, vec![0usize,], "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_owned_bytes_and_nodes_result_span_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult(Span)");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let tups: Vec<(usize, usize)> = result
+        .iter()
+        .map(|x| (x.span().start_idx(), x.span().end_idx()))
+        .collect();
+    let expected: Vec<(usize, usize)> = vec![(0usize, 4usize)];
+    assert_eq!(tups, expected, "result != expected");
+    Ok(())
+}
+#[test]
+fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_owned_bytes_and_nodes_result_using_main_engine(
+) -> Result<(), Box<dyn Error>> {
+    println ! ("on document compressed/atomic_root_true.toml running the query $ (select the root) with Input impl OwnedBytes and result mode NodesResult");
+    let jsonpath_query = JsonPathQuery::parse("$")?;
+    let raw_json = fs::read_to_string("../rsonpath-lib/tests/documents/json/compressed/atomic_root_true.json")?;
+    let input = OwnedBytes::new(&raw_json.as_bytes())?;
+    let engine = MainEngine::compile_query(&jsonpath_query)?;
+    let mut result = vec![];
+    engine.matches(&input, &mut result)?;
+    let utf8: Result<Vec<&str>, _> = result.iter().map(|x| str::from_utf8(x.bytes())).collect();
+    let utf8 = utf8.expect("valid utf8");
+    let expected: Vec<&str> = vec!["true"];
     assert_eq!(utf8, expected, "result != expected");
     Ok(())
 }

--- a/crates/rsonpath-lib/tests/end_to_end.rs
+++ b/crates/rsonpath-lib/tests/end_to_end.rs
@@ -1,4 +1,4 @@
-// bf9bed65f899df486beb41882a8da840
+// 900868b960fe18a9c4aac79ee1aa5e94
 use pretty_assertions::assert_eq;
 use rsonpath::engine::{main::MainEngine, Compiler, Engine};
 use rsonpath::input::*;
@@ -17,7 +17,7 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(453usize, 455usize, 455usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(453usize, 455usize, Some(455usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -29,12 +29,14 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -108,7 +110,7 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(453usize, 455usize, 455usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(453usize, 455usize, Some(455usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -120,12 +122,14 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -199,7 +203,7 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(453usize, 455usize, 455usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(453usize, 455usize, Some(455usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -211,12 +215,14 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -290,7 +296,7 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(453usize, 455usize, 455usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(453usize, 455usize, Some(455usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -302,12 +308,14 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -381,7 +389,7 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(453usize, 455usize, 455usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(453usize, 455usize, Some(455usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -393,12 +401,14 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -472,7 +482,7 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(453usize, 455usize, 455usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(453usize, 455usize, Some(455usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -484,12 +494,14 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -563,7 +575,7 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(810usize, 812usize, 817usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(810usize, 812usize, Some(817usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -575,12 +587,14 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -654,7 +668,7 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(810usize, 812usize, 817usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(810usize, 812usize, Some(817usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -666,12 +680,14 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -745,7 +761,7 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(810usize, 812usize, 817usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(810usize, 812usize, Some(817usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -757,12 +773,14 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -836,7 +854,7 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(810usize, 812usize, 817usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(810usize, 812usize, Some(817usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -848,12 +866,14 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -927,7 +947,7 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(810usize, 812usize, 817usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(810usize, 812usize, Some(817usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -939,12 +959,14 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -1018,7 +1040,7 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(810usize, 812usize, 817usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(810usize, 812usize, Some(817usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -1030,12 +1052,14 @@ fn artificial_json_with_an_object_with_many_leaves_preceding_an_atomic_member_de
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -1109,10 +1133,10 @@ fn artificial_json_with_deep_nesting_and_repeating_member_names_compressed_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (100usize, 106usize, 106usize),
-        (133usize, 139usize, 139usize),
-        (153usize, 159usize, 159usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (100usize, 106usize, Some(106usize)),
+        (133usize, 139usize, Some(139usize)),
+        (153usize, 159usize, Some(159usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -1125,12 +1149,14 @@ fn artificial_json_with_deep_nesting_and_repeating_member_names_compressed_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -1204,10 +1230,10 @@ fn artificial_json_with_deep_nesting_and_repeating_member_names_compressed_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (100usize, 106usize, 106usize),
-        (133usize, 139usize, 139usize),
-        (153usize, 159usize, 159usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (100usize, 106usize, Some(106usize)),
+        (133usize, 139usize, Some(139usize)),
+        (153usize, 159usize, Some(159usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -1220,12 +1246,14 @@ fn artificial_json_with_deep_nesting_and_repeating_member_names_compressed_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -1299,10 +1327,10 @@ fn artificial_json_with_deep_nesting_and_repeating_member_names_compressed_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (100usize, 106usize, 106usize),
-        (133usize, 139usize, 139usize),
-        (153usize, 159usize, 159usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (100usize, 106usize, Some(106usize)),
+        (133usize, 139usize, Some(139usize)),
+        (153usize, 159usize, Some(159usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -1315,12 +1343,14 @@ fn artificial_json_with_deep_nesting_and_repeating_member_names_compressed_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -1394,10 +1424,10 @@ fn artificial_json_with_deep_nesting_and_repeating_member_names_with_query_mix_d
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (986usize, 992usize, 1029usize),
-        (1299usize, 1305usize, 1350usize),
-        (1547usize, 1553usize, 1586usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (986usize, 992usize, Some(1029usize)),
+        (1299usize, 1305usize, Some(1350usize)),
+        (1547usize, 1553usize, Some(1586usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -1410,12 +1440,14 @@ fn artificial_json_with_deep_nesting_and_repeating_member_names_with_query_mix_d
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -1489,10 +1521,10 @@ fn artificial_json_with_deep_nesting_and_repeating_member_names_with_query_mix_d
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (986usize, 992usize, 1029usize),
-        (1299usize, 1305usize, 1350usize),
-        (1547usize, 1553usize, 1586usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (986usize, 992usize, Some(1029usize)),
+        (1299usize, 1305usize, Some(1350usize)),
+        (1547usize, 1553usize, Some(1586usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -1505,12 +1537,14 @@ fn artificial_json_with_deep_nesting_and_repeating_member_names_with_query_mix_d
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -1584,10 +1618,10 @@ fn artificial_json_with_deep_nesting_and_repeating_member_names_with_query_mix_d
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (986usize, 992usize, 1029usize),
-        (1299usize, 1305usize, 1350usize),
-        (1547usize, 1553usize, 1586usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (986usize, 992usize, Some(1029usize)),
+        (1299usize, 1305usize, Some(1350usize)),
+        (1547usize, 1553usize, Some(1586usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -1600,12 +1634,14 @@ fn artificial_json_with_deep_nesting_and_repeating_member_names_with_query_mix_d
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -1679,7 +1715,8 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(27usize, 29usize, 29usize), (40usize, 42usize, 42usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(27usize, 29usize, Some(29usize)), (40usize, 42usize, Some(42usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -1691,12 +1728,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -1770,7 +1809,8 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(27usize, 29usize, 29usize), (40usize, 42usize, 42usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(27usize, 29usize, Some(29usize)), (40usize, 42usize, Some(42usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -1782,12 +1822,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -1861,7 +1903,8 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(27usize, 29usize, 29usize), (40usize, 42usize, 42usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(27usize, 29usize, Some(29usize)), (40usize, 42usize, Some(42usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -1873,12 +1916,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -1952,7 +1997,8 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(27usize, 29usize, 29usize), (40usize, 42usize, 42usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(27usize, 29usize, Some(29usize)), (40usize, 42usize, Some(42usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -1964,12 +2010,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -2043,7 +2091,8 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(27usize, 29usize, 29usize), (40usize, 42usize, 42usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(27usize, 29usize, Some(29usize)), (40usize, 42usize, Some(42usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -2055,12 +2104,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -2134,7 +2185,8 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(27usize, 29usize, 29usize), (40usize, 42usize, 42usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(27usize, 29usize, Some(29usize)), (40usize, 42usize, Some(42usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -2146,12 +2198,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -2225,7 +2279,8 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(27usize, 29usize, 29usize), (40usize, 42usize, 42usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(27usize, 29usize, Some(29usize)), (40usize, 42usize, Some(42usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -2237,12 +2292,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -2316,7 +2373,8 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(27usize, 29usize, 29usize), (40usize, 42usize, 42usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(27usize, 29usize, Some(29usize)), (40usize, 42usize, Some(42usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -2328,12 +2386,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -2407,7 +2467,8 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(27usize, 29usize, 29usize), (40usize, 42usize, 42usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(27usize, 29usize, Some(29usize)), (40usize, 42usize, Some(42usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -2419,12 +2480,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -2498,7 +2561,10 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(150usize, 152usize, 165usize), (257usize, 259usize, 272usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (150usize, 152usize, Some(165usize)),
+        (257usize, 259usize, Some(272usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -2510,12 +2576,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -2589,7 +2657,10 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(150usize, 152usize, 165usize), (257usize, 259usize, 272usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (150usize, 152usize, Some(165usize)),
+        (257usize, 259usize, Some(272usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -2601,12 +2672,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -2680,7 +2753,10 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(150usize, 152usize, 165usize), (257usize, 259usize, 272usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (150usize, 152usize, Some(165usize)),
+        (257usize, 259usize, Some(272usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -2692,12 +2768,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -2771,7 +2849,10 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(150usize, 152usize, 165usize), (257usize, 259usize, 272usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (150usize, 152usize, Some(165usize)),
+        (257usize, 259usize, Some(272usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -2783,12 +2864,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -2862,7 +2945,10 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(150usize, 152usize, 165usize), (257usize, 259usize, 272usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (150usize, 152usize, Some(165usize)),
+        (257usize, 259usize, Some(272usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -2874,12 +2960,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -2953,7 +3041,10 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(150usize, 152usize, 165usize), (257usize, 259usize, 272usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (150usize, 152usize, Some(165usize)),
+        (257usize, 259usize, Some(272usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -2965,12 +3056,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -3044,7 +3137,10 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(150usize, 152usize, 165usize), (257usize, 259usize, 272usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (150usize, 152usize, Some(165usize)),
+        (257usize, 259usize, Some(272usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -3056,12 +3152,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -3135,7 +3233,10 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(150usize, 152usize, 165usize), (257usize, 259usize, 272usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (150usize, 152usize, Some(165usize)),
+        (257usize, 259usize, Some(272usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -3147,12 +3248,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -3226,7 +3329,10 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(150usize, 152usize, 165usize), (257usize, 259usize, 272usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (150usize, 152usize, Some(165usize)),
+        (257usize, 259usize, Some(272usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -3238,12 +3344,14 @@ fn artificial_json_with_excessive_whitespace_between_structural_colons_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -3317,13 +3425,13 @@ fn artificial_json_with_many_equal_member_names_nested_in_each_other_to_stress_t
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (40usize, 48usize, 48usize),
-        (109usize, 203usize, 203usize),
-        (190usize, 198usize, 198usize),
-        (241usize, 249usize, 249usize),
-        (264usize, 272usize, 272usize),
-        (281usize, 289usize, 289usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (40usize, 48usize, Some(48usize)),
+        (109usize, 203usize, Some(203usize)),
+        (190usize, 198usize, Some(198usize)),
+        (241usize, 249usize, Some(249usize)),
+        (264usize, 272usize, Some(272usize)),
+        (281usize, 289usize, Some(289usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -3336,12 +3444,14 @@ fn artificial_json_with_many_equal_member_names_nested_in_each_other_to_stress_t
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -3426,13 +3536,13 @@ fn artificial_json_with_many_equal_member_names_nested_in_each_other_to_stress_t
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (40usize, 48usize, 48usize),
-        (109usize, 203usize, 203usize),
-        (190usize, 198usize, 198usize),
-        (241usize, 249usize, 249usize),
-        (264usize, 272usize, 272usize),
-        (281usize, 289usize, 289usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (40usize, 48usize, Some(48usize)),
+        (109usize, 203usize, Some(203usize)),
+        (190usize, 198usize, Some(198usize)),
+        (241usize, 249usize, Some(249usize)),
+        (264usize, 272usize, Some(272usize)),
+        (281usize, 289usize, Some(289usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -3445,12 +3555,14 @@ fn artificial_json_with_many_equal_member_names_nested_in_each_other_to_stress_t
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -3535,13 +3647,13 @@ fn artificial_json_with_many_equal_member_names_nested_in_each_other_to_stress_t
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (40usize, 48usize, 48usize),
-        (109usize, 203usize, 203usize),
-        (190usize, 198usize, 198usize),
-        (241usize, 249usize, 249usize),
-        (264usize, 272usize, 272usize),
-        (281usize, 289usize, 289usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (40usize, 48usize, Some(48usize)),
+        (109usize, 203usize, Some(203usize)),
+        (190usize, 198usize, Some(198usize)),
+        (241usize, 249usize, Some(249usize)),
+        (264usize, 272usize, Some(272usize)),
+        (281usize, 289usize, Some(289usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -3554,12 +3666,14 @@ fn artificial_json_with_many_equal_member_names_nested_in_each_other_to_stress_t
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -3644,13 +3758,13 @@ fn artificial_json_with_many_equal_member_names_nested_in_each_other_to_stress_t
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (200usize, 208usize, 237usize),
-        (758usize, 1507usize, 1548usize),
-        (1229usize, 1237usize, 1298usize),
-        (1905usize, 1913usize, 1913usize),
-        (2042usize, 2050usize, 2087usize),
-        (2209usize, 2217usize, 2238usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (200usize, 208usize, Some(237usize)),
+        (758usize, 1507usize, Some(1548usize)),
+        (1229usize, 1237usize, Some(1298usize)),
+        (1905usize, 1913usize, Some(1913usize)),
+        (2042usize, 2050usize, Some(2087usize)),
+        (2209usize, 2217usize, Some(2238usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -3663,12 +3777,14 @@ fn artificial_json_with_many_equal_member_names_nested_in_each_other_to_stress_t
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -3753,13 +3869,13 @@ fn artificial_json_with_many_equal_member_names_nested_in_each_other_to_stress_t
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (200usize, 208usize, 237usize),
-        (758usize, 1507usize, 1548usize),
-        (1229usize, 1237usize, 1298usize),
-        (1905usize, 1913usize, 1913usize),
-        (2042usize, 2050usize, 2087usize),
-        (2209usize, 2217usize, 2238usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (200usize, 208usize, Some(237usize)),
+        (758usize, 1507usize, Some(1548usize)),
+        (1229usize, 1237usize, Some(1298usize)),
+        (1905usize, 1913usize, Some(1913usize)),
+        (2042usize, 2050usize, Some(2087usize)),
+        (2209usize, 2217usize, Some(2238usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -3772,12 +3888,14 @@ fn artificial_json_with_many_equal_member_names_nested_in_each_other_to_stress_t
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -3862,13 +3980,13 @@ fn artificial_json_with_many_equal_member_names_nested_in_each_other_to_stress_t
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (200usize, 208usize, 237usize),
-        (758usize, 1507usize, 1548usize),
-        (1229usize, 1237usize, 1298usize),
-        (1905usize, 1913usize, 1913usize),
-        (2042usize, 2050usize, 2087usize),
-        (2209usize, 2217usize, 2238usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (200usize, 208usize, Some(237usize)),
+        (758usize, 1507usize, Some(1548usize)),
+        (1229usize, 1237usize, Some(1298usize)),
+        (1905usize, 1913usize, Some(1913usize)),
+        (2042usize, 2050usize, Some(2087usize)),
+        (2209usize, 2217usize, Some(2238usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -3881,12 +3999,14 @@ fn artificial_json_with_many_equal_member_names_nested_in_each_other_to_stress_t
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -3972,19 +4092,19 @@ fn deeply_nested_list_with_all_data_types_compressed_with_query_select_all_nodes
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (33usize, 35usize, 35usize),
-        (44usize, 45usize, 45usize),
-        (46usize, 47usize, 47usize),
-        (48usize, 50usize, 50usize),
-        (51usize, 53usize, 53usize),
-        (54usize, 58usize, 58usize),
-        (55usize, 57usize, 57usize),
-        (59usize, 64usize, 64usize),
-        (65usize, 69usize, 69usize),
-        (70usize, 75usize, 75usize),
-        (76usize, 80usize, 80usize),
-        (92usize, 94usize, 94usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (33usize, 35usize, Some(35usize)),
+        (44usize, 45usize, Some(45usize)),
+        (46usize, 47usize, Some(47usize)),
+        (48usize, 50usize, Some(50usize)),
+        (51usize, 53usize, Some(53usize)),
+        (54usize, 58usize, Some(58usize)),
+        (55usize, 57usize, Some(57usize)),
+        (59usize, 64usize, Some(64usize)),
+        (65usize, 69usize, Some(69usize)),
+        (70usize, 75usize, Some(75usize)),
+        (76usize, 80usize, Some(80usize)),
+        (92usize, 94usize, Some(94usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -3997,12 +4117,14 @@ fn deeply_nested_list_with_all_data_types_compressed_with_query_select_all_nodes
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -4102,19 +4224,19 @@ fn deeply_nested_list_with_all_data_types_compressed_with_query_select_all_nodes
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (33usize, 35usize, 35usize),
-        (44usize, 45usize, 45usize),
-        (46usize, 47usize, 47usize),
-        (48usize, 50usize, 50usize),
-        (51usize, 53usize, 53usize),
-        (54usize, 58usize, 58usize),
-        (55usize, 57usize, 57usize),
-        (59usize, 64usize, 64usize),
-        (65usize, 69usize, 69usize),
-        (70usize, 75usize, 75usize),
-        (76usize, 80usize, 80usize),
-        (92usize, 94usize, 94usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (33usize, 35usize, Some(35usize)),
+        (44usize, 45usize, Some(45usize)),
+        (46usize, 47usize, Some(47usize)),
+        (48usize, 50usize, Some(50usize)),
+        (51usize, 53usize, Some(53usize)),
+        (54usize, 58usize, Some(58usize)),
+        (55usize, 57usize, Some(57usize)),
+        (59usize, 64usize, Some(64usize)),
+        (65usize, 69usize, Some(69usize)),
+        (70usize, 75usize, Some(75usize)),
+        (76usize, 80usize, Some(80usize)),
+        (92usize, 94usize, Some(94usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -4127,12 +4249,14 @@ fn deeply_nested_list_with_all_data_types_compressed_with_query_select_all_nodes
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -4232,19 +4356,19 @@ fn deeply_nested_list_with_all_data_types_compressed_with_query_select_all_nodes
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (33usize, 35usize, 35usize),
-        (44usize, 45usize, 45usize),
-        (46usize, 47usize, 47usize),
-        (48usize, 50usize, 50usize),
-        (51usize, 53usize, 53usize),
-        (54usize, 58usize, 58usize),
-        (55usize, 57usize, 57usize),
-        (59usize, 64usize, 64usize),
-        (65usize, 69usize, 69usize),
-        (70usize, 75usize, 75usize),
-        (76usize, 80usize, 80usize),
-        (92usize, 94usize, 94usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (33usize, 35usize, Some(35usize)),
+        (44usize, 45usize, Some(45usize)),
+        (46usize, 47usize, Some(47usize)),
+        (48usize, 50usize, Some(50usize)),
+        (51usize, 53usize, Some(53usize)),
+        (54usize, 58usize, Some(58usize)),
+        (55usize, 57usize, Some(57usize)),
+        (59usize, 64usize, Some(64usize)),
+        (65usize, 69usize, Some(69usize)),
+        (70usize, 75usize, Some(75usize)),
+        (76usize, 80usize, Some(80usize)),
+        (92usize, 94usize, Some(94usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -4257,12 +4381,14 @@ fn deeply_nested_list_with_all_data_types_compressed_with_query_select_all_nodes
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -4362,18 +4488,18 @@ fn deeply_nested_list_with_all_data_types_compressed_with_query_select_all_nodes
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (33usize, 35usize, 35usize),
-        (44usize, 45usize, 45usize),
-        (46usize, 47usize, 47usize),
-        (48usize, 50usize, 50usize),
-        (51usize, 53usize, 53usize),
-        (54usize, 58usize, 58usize),
-        (59usize, 64usize, 64usize),
-        (65usize, 69usize, 69usize),
-        (70usize, 75usize, 75usize),
-        (76usize, 80usize, 80usize),
-        (92usize, 94usize, 94usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (33usize, 35usize, Some(35usize)),
+        (44usize, 45usize, Some(45usize)),
+        (46usize, 47usize, Some(47usize)),
+        (48usize, 50usize, Some(50usize)),
+        (51usize, 53usize, Some(53usize)),
+        (54usize, 58usize, Some(58usize)),
+        (59usize, 64usize, Some(64usize)),
+        (65usize, 69usize, Some(69usize)),
+        (70usize, 75usize, Some(75usize)),
+        (76usize, 80usize, Some(80usize)),
+        (92usize, 94usize, Some(94usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -4386,12 +4512,14 @@ fn deeply_nested_list_with_all_data_types_compressed_with_query_select_all_nodes
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -4488,18 +4616,18 @@ fn deeply_nested_list_with_all_data_types_compressed_with_query_select_all_nodes
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (33usize, 35usize, 35usize),
-        (44usize, 45usize, 45usize),
-        (46usize, 47usize, 47usize),
-        (48usize, 50usize, 50usize),
-        (51usize, 53usize, 53usize),
-        (54usize, 58usize, 58usize),
-        (59usize, 64usize, 64usize),
-        (65usize, 69usize, 69usize),
-        (70usize, 75usize, 75usize),
-        (76usize, 80usize, 80usize),
-        (92usize, 94usize, 94usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (33usize, 35usize, Some(35usize)),
+        (44usize, 45usize, Some(45usize)),
+        (46usize, 47usize, Some(47usize)),
+        (48usize, 50usize, Some(50usize)),
+        (51usize, 53usize, Some(53usize)),
+        (54usize, 58usize, Some(58usize)),
+        (59usize, 64usize, Some(64usize)),
+        (65usize, 69usize, Some(69usize)),
+        (70usize, 75usize, Some(75usize)),
+        (76usize, 80usize, Some(80usize)),
+        (92usize, 94usize, Some(94usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -4512,12 +4640,14 @@ fn deeply_nested_list_with_all_data_types_compressed_with_query_select_all_nodes
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -4614,18 +4744,18 @@ fn deeply_nested_list_with_all_data_types_compressed_with_query_select_all_nodes
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (33usize, 35usize, 35usize),
-        (44usize, 45usize, 45usize),
-        (46usize, 47usize, 47usize),
-        (48usize, 50usize, 50usize),
-        (51usize, 53usize, 53usize),
-        (54usize, 58usize, 58usize),
-        (59usize, 64usize, 64usize),
-        (65usize, 69usize, 69usize),
-        (70usize, 75usize, 75usize),
-        (76usize, 80usize, 80usize),
-        (92usize, 94usize, 94usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (33usize, 35usize, Some(35usize)),
+        (44usize, 45usize, Some(45usize)),
+        (46usize, 47usize, Some(47usize)),
+        (48usize, 50usize, Some(50usize)),
+        (51usize, 53usize, Some(53usize)),
+        (54usize, 58usize, Some(58usize)),
+        (59usize, 64usize, Some(64usize)),
+        (65usize, 69usize, Some(69usize)),
+        (70usize, 75usize, Some(75usize)),
+        (76usize, 80usize, Some(80usize)),
+        (92usize, 94usize, Some(94usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -4638,12 +4768,14 @@ fn deeply_nested_list_with_all_data_types_compressed_with_query_select_all_nodes
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -4739,19 +4871,19 @@ fn deeply_nested_list_with_all_data_types_with_query_select_all_nodes_in_bs_with
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (228usize, 230usize, 263usize),
-        (401usize, 402usize, 402usize),
-        (440usize, 441usize, 441usize),
-        (479usize, 481usize, 481usize),
-        (519usize, 521usize, 521usize),
-        (559usize, 641usize, 641usize),
-        (601usize, 603usize, 640usize),
-        (679usize, 684usize, 684usize),
-        (722usize, 726usize, 726usize),
-        (764usize, 769usize, 769usize),
-        (807usize, 811usize, 844usize),
-        (1012usize, 1014usize, 1035usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (228usize, 230usize, Some(263usize)),
+        (401usize, 402usize, Some(402usize)),
+        (440usize, 441usize, Some(441usize)),
+        (479usize, 481usize, Some(481usize)),
+        (519usize, 521usize, Some(521usize)),
+        (559usize, 641usize, Some(641usize)),
+        (601usize, 603usize, Some(640usize)),
+        (679usize, 684usize, Some(684usize)),
+        (722usize, 726usize, Some(726usize)),
+        (764usize, 769usize, Some(769usize)),
+        (807usize, 811usize, Some(844usize)),
+        (1012usize, 1014usize, Some(1035usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -4764,12 +4896,14 @@ fn deeply_nested_list_with_all_data_types_with_query_select_all_nodes_in_bs_with
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -4876,19 +5010,19 @@ fn deeply_nested_list_with_all_data_types_with_query_select_all_nodes_in_bs_with
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (228usize, 230usize, 263usize),
-        (401usize, 402usize, 402usize),
-        (440usize, 441usize, 441usize),
-        (479usize, 481usize, 481usize),
-        (519usize, 521usize, 521usize),
-        (559usize, 641usize, 641usize),
-        (601usize, 603usize, 640usize),
-        (679usize, 684usize, 684usize),
-        (722usize, 726usize, 726usize),
-        (764usize, 769usize, 769usize),
-        (807usize, 811usize, 844usize),
-        (1012usize, 1014usize, 1035usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (228usize, 230usize, Some(263usize)),
+        (401usize, 402usize, Some(402usize)),
+        (440usize, 441usize, Some(441usize)),
+        (479usize, 481usize, Some(481usize)),
+        (519usize, 521usize, Some(521usize)),
+        (559usize, 641usize, Some(641usize)),
+        (601usize, 603usize, Some(640usize)),
+        (679usize, 684usize, Some(684usize)),
+        (722usize, 726usize, Some(726usize)),
+        (764usize, 769usize, Some(769usize)),
+        (807usize, 811usize, Some(844usize)),
+        (1012usize, 1014usize, Some(1035usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -4901,12 +5035,14 @@ fn deeply_nested_list_with_all_data_types_with_query_select_all_nodes_in_bs_with
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -5013,19 +5149,19 @@ fn deeply_nested_list_with_all_data_types_with_query_select_all_nodes_in_bs_with
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (228usize, 230usize, 263usize),
-        (401usize, 402usize, 402usize),
-        (440usize, 441usize, 441usize),
-        (479usize, 481usize, 481usize),
-        (519usize, 521usize, 521usize),
-        (559usize, 641usize, 641usize),
-        (601usize, 603usize, 640usize),
-        (679usize, 684usize, 684usize),
-        (722usize, 726usize, 726usize),
-        (764usize, 769usize, 769usize),
-        (807usize, 811usize, 844usize),
-        (1012usize, 1014usize, 1035usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (228usize, 230usize, Some(263usize)),
+        (401usize, 402usize, Some(402usize)),
+        (440usize, 441usize, Some(441usize)),
+        (479usize, 481usize, Some(481usize)),
+        (519usize, 521usize, Some(521usize)),
+        (559usize, 641usize, Some(641usize)),
+        (601usize, 603usize, Some(640usize)),
+        (679usize, 684usize, Some(684usize)),
+        (722usize, 726usize, Some(726usize)),
+        (764usize, 769usize, Some(769usize)),
+        (807usize, 811usize, Some(844usize)),
+        (1012usize, 1014usize, Some(1035usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -5038,12 +5174,14 @@ fn deeply_nested_list_with_all_data_types_with_query_select_all_nodes_in_bs_with
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -5150,18 +5288,18 @@ fn deeply_nested_list_with_all_data_types_with_query_select_all_nodes_in_bs_with
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (228usize, 230usize, 263usize),
-        (401usize, 402usize, 402usize),
-        (440usize, 441usize, 441usize),
-        (479usize, 481usize, 481usize),
-        (519usize, 521usize, 521usize),
-        (559usize, 641usize, 641usize),
-        (679usize, 684usize, 684usize),
-        (722usize, 726usize, 726usize),
-        (764usize, 769usize, 769usize),
-        (807usize, 811usize, 844usize),
-        (1012usize, 1014usize, 1035usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (228usize, 230usize, Some(263usize)),
+        (401usize, 402usize, Some(402usize)),
+        (440usize, 441usize, Some(441usize)),
+        (479usize, 481usize, Some(481usize)),
+        (519usize, 521usize, Some(521usize)),
+        (559usize, 641usize, Some(641usize)),
+        (679usize, 684usize, Some(684usize)),
+        (722usize, 726usize, Some(726usize)),
+        (764usize, 769usize, Some(769usize)),
+        (807usize, 811usize, Some(844usize)),
+        (1012usize, 1014usize, Some(1035usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -5174,12 +5312,14 @@ fn deeply_nested_list_with_all_data_types_with_query_select_all_nodes_in_bs_with
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -5284,18 +5424,18 @@ fn deeply_nested_list_with_all_data_types_with_query_select_all_nodes_in_bs_with
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (228usize, 230usize, 263usize),
-        (401usize, 402usize, 402usize),
-        (440usize, 441usize, 441usize),
-        (479usize, 481usize, 481usize),
-        (519usize, 521usize, 521usize),
-        (559usize, 641usize, 641usize),
-        (679usize, 684usize, 684usize),
-        (722usize, 726usize, 726usize),
-        (764usize, 769usize, 769usize),
-        (807usize, 811usize, 844usize),
-        (1012usize, 1014usize, 1035usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (228usize, 230usize, Some(263usize)),
+        (401usize, 402usize, Some(402usize)),
+        (440usize, 441usize, Some(441usize)),
+        (479usize, 481usize, Some(481usize)),
+        (519usize, 521usize, Some(521usize)),
+        (559usize, 641usize, Some(641usize)),
+        (679usize, 684usize, Some(684usize)),
+        (722usize, 726usize, Some(726usize)),
+        (764usize, 769usize, Some(769usize)),
+        (807usize, 811usize, Some(844usize)),
+        (1012usize, 1014usize, Some(1035usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -5308,12 +5448,14 @@ fn deeply_nested_list_with_all_data_types_with_query_select_all_nodes_in_bs_with
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -5418,18 +5560,18 @@ fn deeply_nested_list_with_all_data_types_with_query_select_all_nodes_in_bs_with
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (228usize, 230usize, 263usize),
-        (401usize, 402usize, 402usize),
-        (440usize, 441usize, 441usize),
-        (479usize, 481usize, 481usize),
-        (519usize, 521usize, 521usize),
-        (559usize, 641usize, 641usize),
-        (679usize, 684usize, 684usize),
-        (722usize, 726usize, 726usize),
-        (764usize, 769usize, 769usize),
-        (807usize, 811usize, 844usize),
-        (1012usize, 1014usize, 1035usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (228usize, 230usize, Some(263usize)),
+        (401usize, 402usize, Some(402usize)),
+        (440usize, 441usize, Some(441usize)),
+        (479usize, 481usize, Some(481usize)),
+        (519usize, 521usize, Some(521usize)),
+        (559usize, 641usize, Some(641usize)),
+        (679usize, 684usize, Some(684usize)),
+        (722usize, 726usize, Some(726usize)),
+        (764usize, 769usize, Some(769usize)),
+        (807usize, 811usize, Some(844usize)),
+        (1012usize, 1014usize, Some(1035usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -5442,12 +5584,14 @@ fn deeply_nested_list_with_all_data_types_with_query_select_all_nodes_in_bs_with
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -5552,16 +5696,16 @@ fn deeply_nested_lists_compressed_with_query_select_all_nodes_in_the_top_level_l
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (16usize, 17usize, 17usize),
-        (18usize, 19usize, 19usize),
-        (20usize, 22usize, 22usize),
-        (23usize, 25usize, 25usize),
-        (26usize, 34usize, 34usize),
-        (27usize, 33usize, 33usize),
-        (28usize, 32usize, 32usize),
-        (29usize, 31usize, 31usize),
-        (35usize, 36usize, 36usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (16usize, 17usize, Some(17usize)),
+        (18usize, 19usize, Some(19usize)),
+        (20usize, 22usize, Some(22usize)),
+        (23usize, 25usize, Some(25usize)),
+        (26usize, 34usize, Some(34usize)),
+        (27usize, 33usize, Some(33usize)),
+        (28usize, 32usize, Some(32usize)),
+        (29usize, 31usize, Some(31usize)),
+        (35usize, 36usize, Some(36usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -5574,12 +5718,14 @@ fn deeply_nested_lists_compressed_with_query_select_all_nodes_in_the_top_level_l
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -5667,16 +5813,16 @@ fn deeply_nested_lists_compressed_with_query_select_all_nodes_in_the_top_level_l
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (16usize, 17usize, 17usize),
-        (18usize, 19usize, 19usize),
-        (20usize, 22usize, 22usize),
-        (23usize, 25usize, 25usize),
-        (26usize, 34usize, 34usize),
-        (27usize, 33usize, 33usize),
-        (28usize, 32usize, 32usize),
-        (29usize, 31usize, 31usize),
-        (35usize, 36usize, 36usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (16usize, 17usize, Some(17usize)),
+        (18usize, 19usize, Some(19usize)),
+        (20usize, 22usize, Some(22usize)),
+        (23usize, 25usize, Some(25usize)),
+        (26usize, 34usize, Some(34usize)),
+        (27usize, 33usize, Some(33usize)),
+        (28usize, 32usize, Some(32usize)),
+        (29usize, 31usize, Some(31usize)),
+        (35usize, 36usize, Some(36usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -5689,12 +5835,14 @@ fn deeply_nested_lists_compressed_with_query_select_all_nodes_in_the_top_level_l
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -5782,16 +5930,16 @@ fn deeply_nested_lists_compressed_with_query_select_all_nodes_in_the_top_level_l
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (16usize, 17usize, 17usize),
-        (18usize, 19usize, 19usize),
-        (20usize, 22usize, 22usize),
-        (23usize, 25usize, 25usize),
-        (26usize, 34usize, 34usize),
-        (27usize, 33usize, 33usize),
-        (28usize, 32usize, 32usize),
-        (29usize, 31usize, 31usize),
-        (35usize, 36usize, 36usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (16usize, 17usize, Some(17usize)),
+        (18usize, 19usize, Some(19usize)),
+        (20usize, 22usize, Some(22usize)),
+        (23usize, 25usize, Some(25usize)),
+        (26usize, 34usize, Some(34usize)),
+        (27usize, 33usize, Some(33usize)),
+        (28usize, 32usize, Some(32usize)),
+        (29usize, 31usize, Some(31usize)),
+        (35usize, 36usize, Some(36usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -5804,12 +5952,14 @@ fn deeply_nested_lists_compressed_with_query_select_all_nodes_in_the_top_level_l
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -5897,13 +6047,13 @@ fn deeply_nested_lists_compressed_with_query_select_all_nodes_in_the_top_level_l
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (16usize, 17usize, 17usize),
-        (18usize, 19usize, 19usize),
-        (20usize, 22usize, 22usize),
-        (23usize, 25usize, 25usize),
-        (26usize, 34usize, 34usize),
-        (35usize, 36usize, 36usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (16usize, 17usize, Some(17usize)),
+        (18usize, 19usize, Some(19usize)),
+        (20usize, 22usize, Some(22usize)),
+        (23usize, 25usize, Some(25usize)),
+        (26usize, 34usize, Some(34usize)),
+        (35usize, 36usize, Some(36usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -5916,12 +6066,14 @@ fn deeply_nested_lists_compressed_with_query_select_all_nodes_in_the_top_level_l
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -6006,13 +6158,13 @@ fn deeply_nested_lists_compressed_with_query_select_all_nodes_in_the_top_level_l
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (16usize, 17usize, 17usize),
-        (18usize, 19usize, 19usize),
-        (20usize, 22usize, 22usize),
-        (23usize, 25usize, 25usize),
-        (26usize, 34usize, 34usize),
-        (35usize, 36usize, 36usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (16usize, 17usize, Some(17usize)),
+        (18usize, 19usize, Some(19usize)),
+        (20usize, 22usize, Some(22usize)),
+        (23usize, 25usize, Some(25usize)),
+        (26usize, 34usize, Some(34usize)),
+        (35usize, 36usize, Some(36usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -6025,12 +6177,14 @@ fn deeply_nested_lists_compressed_with_query_select_all_nodes_in_the_top_level_l
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -6115,13 +6269,13 @@ fn deeply_nested_lists_compressed_with_query_select_all_nodes_in_the_top_level_l
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (16usize, 17usize, 17usize),
-        (18usize, 19usize, 19usize),
-        (20usize, 22usize, 22usize),
-        (23usize, 25usize, 25usize),
-        (26usize, 34usize, 34usize),
-        (35usize, 36usize, 36usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (16usize, 17usize, Some(17usize)),
+        (18usize, 19usize, Some(19usize)),
+        (20usize, 22usize, Some(22usize)),
+        (23usize, 25usize, Some(25usize)),
+        (26usize, 34usize, Some(34usize)),
+        (35usize, 36usize, Some(36usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -6134,12 +6288,14 @@ fn deeply_nested_lists_compressed_with_query_select_all_nodes_in_the_top_level_l
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -6224,16 +6380,16 @@ fn deeply_nested_lists_with_query_select_all_nodes_in_the_top_level_list_and_bel
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (63usize, 64usize, 64usize),
-        (82usize, 83usize, 83usize),
-        (101usize, 103usize, 103usize),
-        (121usize, 123usize, 123usize),
-        (141usize, 287usize, 287usize),
-        (163usize, 269usize, 286usize),
-        (189usize, 247usize, 268usize),
-        (219usize, 221usize, 246usize),
-        (305usize, 306usize, 319usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (63usize, 64usize, Some(64usize)),
+        (82usize, 83usize, Some(83usize)),
+        (101usize, 103usize, Some(103usize)),
+        (121usize, 123usize, Some(123usize)),
+        (141usize, 287usize, Some(287usize)),
+        (163usize, 269usize, Some(286usize)),
+        (189usize, 247usize, Some(268usize)),
+        (219usize, 221usize, Some(246usize)),
+        (305usize, 306usize, Some(319usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -6246,12 +6402,14 @@ fn deeply_nested_lists_with_query_select_all_nodes_in_the_top_level_list_and_bel
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -6339,16 +6497,16 @@ fn deeply_nested_lists_with_query_select_all_nodes_in_the_top_level_list_and_bel
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (63usize, 64usize, 64usize),
-        (82usize, 83usize, 83usize),
-        (101usize, 103usize, 103usize),
-        (121usize, 123usize, 123usize),
-        (141usize, 287usize, 287usize),
-        (163usize, 269usize, 286usize),
-        (189usize, 247usize, 268usize),
-        (219usize, 221usize, 246usize),
-        (305usize, 306usize, 319usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (63usize, 64usize, Some(64usize)),
+        (82usize, 83usize, Some(83usize)),
+        (101usize, 103usize, Some(103usize)),
+        (121usize, 123usize, Some(123usize)),
+        (141usize, 287usize, Some(287usize)),
+        (163usize, 269usize, Some(286usize)),
+        (189usize, 247usize, Some(268usize)),
+        (219usize, 221usize, Some(246usize)),
+        (305usize, 306usize, Some(319usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -6361,12 +6519,14 @@ fn deeply_nested_lists_with_query_select_all_nodes_in_the_top_level_list_and_bel
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -6454,16 +6614,16 @@ fn deeply_nested_lists_with_query_select_all_nodes_in_the_top_level_list_and_bel
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (63usize, 64usize, 64usize),
-        (82usize, 83usize, 83usize),
-        (101usize, 103usize, 103usize),
-        (121usize, 123usize, 123usize),
-        (141usize, 287usize, 287usize),
-        (163usize, 269usize, 286usize),
-        (189usize, 247usize, 268usize),
-        (219usize, 221usize, 246usize),
-        (305usize, 306usize, 319usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (63usize, 64usize, Some(64usize)),
+        (82usize, 83usize, Some(83usize)),
+        (101usize, 103usize, Some(103usize)),
+        (121usize, 123usize, Some(123usize)),
+        (141usize, 287usize, Some(287usize)),
+        (163usize, 269usize, Some(286usize)),
+        (189usize, 247usize, Some(268usize)),
+        (219usize, 221usize, Some(246usize)),
+        (305usize, 306usize, Some(319usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -6476,12 +6636,14 @@ fn deeply_nested_lists_with_query_select_all_nodes_in_the_top_level_list_and_bel
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -6569,13 +6731,13 @@ fn deeply_nested_lists_with_query_select_all_nodes_in_the_top_level_list_with_bu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (63usize, 64usize, 64usize),
-        (82usize, 83usize, 83usize),
-        (101usize, 103usize, 103usize),
-        (121usize, 123usize, 123usize),
-        (141usize, 287usize, 287usize),
-        (305usize, 306usize, 319usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (63usize, 64usize, Some(64usize)),
+        (82usize, 83usize, Some(83usize)),
+        (101usize, 103usize, Some(103usize)),
+        (121usize, 123usize, Some(123usize)),
+        (141usize, 287usize, Some(287usize)),
+        (305usize, 306usize, Some(319usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -6588,12 +6750,14 @@ fn deeply_nested_lists_with_query_select_all_nodes_in_the_top_level_list_with_bu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -6678,13 +6842,13 @@ fn deeply_nested_lists_with_query_select_all_nodes_in_the_top_level_list_with_mm
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (63usize, 64usize, 64usize),
-        (82usize, 83usize, 83usize),
-        (101usize, 103usize, 103usize),
-        (121usize, 123usize, 123usize),
-        (141usize, 287usize, 287usize),
-        (305usize, 306usize, 319usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (63usize, 64usize, Some(64usize)),
+        (82usize, 83usize, Some(83usize)),
+        (101usize, 103usize, Some(103usize)),
+        (121usize, 123usize, Some(123usize)),
+        (141usize, 287usize, Some(287usize)),
+        (305usize, 306usize, Some(319usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -6697,12 +6861,14 @@ fn deeply_nested_lists_with_query_select_all_nodes_in_the_top_level_list_with_mm
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -6787,13 +6953,13 @@ fn deeply_nested_lists_with_query_select_all_nodes_in_the_top_level_list_with_ow
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (63usize, 64usize, 64usize),
-        (82usize, 83usize, 83usize),
-        (101usize, 103usize, 103usize),
-        (121usize, 123usize, 123usize),
-        (141usize, 287usize, 287usize),
-        (305usize, 306usize, 319usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (63usize, 64usize, Some(64usize)),
+        (82usize, 83usize, Some(83usize)),
+        (101usize, 103usize, Some(103usize)),
+        (121usize, 123usize, Some(123usize)),
+        (141usize, 287usize, Some(287usize)),
+        (305usize, 306usize, Some(319usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -6806,12 +6972,14 @@ fn deeply_nested_lists_with_query_select_all_nodes_in_the_top_level_list_with_ow
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -6896,16 +7064,16 @@ fn deeply_nested_object_with_path_annotations_compressed_with_query_descendant_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (253usize, 270usize, 270usize),
-        (280usize, 284usize, 284usize),
-        (290usize, 693usize, 693usize),
-        (298usize, 318usize, 318usize),
-        (328usize, 332usize, 332usize),
-        (338usize, 692usize, 692usize),
-        (570usize, 604usize, 604usize),
-        (614usize, 618usize, 618usize),
-        (625usize, 687usize, 687usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (253usize, 270usize, Some(270usize)),
+        (280usize, 284usize, Some(284usize)),
+        (290usize, 693usize, Some(693usize)),
+        (298usize, 318usize, Some(318usize)),
+        (328usize, 332usize, Some(332usize)),
+        (338usize, 692usize, Some(692usize)),
+        (570usize, 604usize, Some(604usize)),
+        (614usize, 618usize, Some(618usize)),
+        (625usize, 687usize, Some(687usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -6918,12 +7086,14 @@ fn deeply_nested_object_with_path_annotations_compressed_with_query_descendant_a
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -7011,16 +7181,16 @@ fn deeply_nested_object_with_path_annotations_compressed_with_query_descendant_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (253usize, 270usize, 270usize),
-        (280usize, 284usize, 284usize),
-        (290usize, 693usize, 693usize),
-        (298usize, 318usize, 318usize),
-        (328usize, 332usize, 332usize),
-        (338usize, 692usize, 692usize),
-        (570usize, 604usize, 604usize),
-        (614usize, 618usize, 618usize),
-        (625usize, 687usize, 687usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (253usize, 270usize, Some(270usize)),
+        (280usize, 284usize, Some(284usize)),
+        (290usize, 693usize, Some(693usize)),
+        (298usize, 318usize, Some(318usize)),
+        (328usize, 332usize, Some(332usize)),
+        (338usize, 692usize, Some(692usize)),
+        (570usize, 604usize, Some(604usize)),
+        (614usize, 618usize, Some(618usize)),
+        (625usize, 687usize, Some(687usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -7033,12 +7203,14 @@ fn deeply_nested_object_with_path_annotations_compressed_with_query_descendant_a
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -7126,16 +7298,16 @@ fn deeply_nested_object_with_path_annotations_compressed_with_query_descendant_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (253usize, 270usize, 270usize),
-        (280usize, 284usize, 284usize),
-        (290usize, 693usize, 693usize),
-        (298usize, 318usize, 318usize),
-        (328usize, 332usize, 332usize),
-        (338usize, 692usize, 692usize),
-        (570usize, 604usize, 604usize),
-        (614usize, 618usize, 618usize),
-        (625usize, 687usize, 687usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (253usize, 270usize, Some(270usize)),
+        (280usize, 284usize, Some(284usize)),
+        (290usize, 693usize, Some(693usize)),
+        (298usize, 318usize, Some(318usize)),
+        (328usize, 332usize, Some(332usize)),
+        (338usize, 692usize, Some(692usize)),
+        (570usize, 604usize, Some(604usize)),
+        (614usize, 618usize, Some(618usize)),
+        (625usize, 687usize, Some(687usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -7148,12 +7320,14 @@ fn deeply_nested_object_with_path_annotations_compressed_with_query_descendant_a
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -7241,16 +7415,16 @@ fn deeply_nested_object_with_path_annotations_with_query_descendant_a_star_star_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (654usize, 671usize, 671usize),
-        (711usize, 715usize, 715usize),
-        (751usize, 2349usize, 2374usize),
-        (793usize, 813usize, 813usize),
-        (857usize, 861usize, 861usize),
-        (901usize, 2319usize, 2348usize),
-        (1715usize, 1749usize, 1749usize),
-        (1813usize, 1817usize, 1817usize),
-        (1878usize, 2109usize, 2158usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (654usize, 671usize, Some(671usize)),
+        (711usize, 715usize, Some(715usize)),
+        (751usize, 2349usize, Some(2374usize)),
+        (793usize, 813usize, Some(813usize)),
+        (857usize, 861usize, Some(861usize)),
+        (901usize, 2319usize, Some(2348usize)),
+        (1715usize, 1749usize, Some(1749usize)),
+        (1813usize, 1817usize, Some(1817usize)),
+        (1878usize, 2109usize, Some(2158usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -7263,12 +7437,14 @@ fn deeply_nested_object_with_path_annotations_with_query_descendant_a_star_star_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -7356,16 +7532,16 @@ fn deeply_nested_object_with_path_annotations_with_query_descendant_a_star_star_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (654usize, 671usize, 671usize),
-        (711usize, 715usize, 715usize),
-        (751usize, 2349usize, 2374usize),
-        (793usize, 813usize, 813usize),
-        (857usize, 861usize, 861usize),
-        (901usize, 2319usize, 2348usize),
-        (1715usize, 1749usize, 1749usize),
-        (1813usize, 1817usize, 1817usize),
-        (1878usize, 2109usize, 2158usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (654usize, 671usize, Some(671usize)),
+        (711usize, 715usize, Some(715usize)),
+        (751usize, 2349usize, Some(2374usize)),
+        (793usize, 813usize, Some(813usize)),
+        (857usize, 861usize, Some(861usize)),
+        (901usize, 2319usize, Some(2348usize)),
+        (1715usize, 1749usize, Some(1749usize)),
+        (1813usize, 1817usize, Some(1817usize)),
+        (1878usize, 2109usize, Some(2158usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -7378,12 +7554,14 @@ fn deeply_nested_object_with_path_annotations_with_query_descendant_a_star_star_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -7471,16 +7649,16 @@ fn deeply_nested_object_with_path_annotations_with_query_descendant_a_star_star_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (654usize, 671usize, 671usize),
-        (711usize, 715usize, 715usize),
-        (751usize, 2349usize, 2374usize),
-        (793usize, 813usize, 813usize),
-        (857usize, 861usize, 861usize),
-        (901usize, 2319usize, 2348usize),
-        (1715usize, 1749usize, 1749usize),
-        (1813usize, 1817usize, 1817usize),
-        (1878usize, 2109usize, 2158usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (654usize, 671usize, Some(671usize)),
+        (711usize, 715usize, Some(715usize)),
+        (751usize, 2349usize, Some(2374usize)),
+        (793usize, 813usize, Some(813usize)),
+        (857usize, 861usize, Some(861usize)),
+        (901usize, 2319usize, Some(2348usize)),
+        (1715usize, 1749usize, Some(1749usize)),
+        (1813usize, 1817usize, Some(1817usize)),
+        (1878usize, 2109usize, Some(2158usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -7493,12 +7671,14 @@ fn deeply_nested_object_with_path_annotations_with_query_descendant_a_star_star_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -7586,15 +7766,15 @@ fn dense_integer_atomic_leaves_without_lists_compressed_with_query_descendant_se
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (20usize, 22usize, 22usize),
-        (27usize, 29usize, 29usize),
-        (34usize, 36usize, 36usize),
-        (41usize, 49usize, 49usize),
-        (46usize, 48usize, 48usize),
-        (54usize, 69usize, 69usize),
-        (59usize, 61usize, 61usize),
-        (66usize, 68usize, 68usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (20usize, 22usize, Some(22usize)),
+        (27usize, 29usize, Some(29usize)),
+        (34usize, 36usize, Some(36usize)),
+        (41usize, 49usize, Some(49usize)),
+        (46usize, 48usize, Some(48usize)),
+        (54usize, 69usize, Some(69usize)),
+        (59usize, 61usize, Some(61usize)),
+        (66usize, 68usize, Some(68usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -7607,12 +7787,14 @@ fn dense_integer_atomic_leaves_without_lists_compressed_with_query_descendant_se
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -7699,15 +7881,15 @@ fn dense_integer_atomic_leaves_without_lists_compressed_with_query_descendant_se
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (20usize, 22usize, 22usize),
-        (27usize, 29usize, 29usize),
-        (34usize, 36usize, 36usize),
-        (41usize, 49usize, 49usize),
-        (46usize, 48usize, 48usize),
-        (54usize, 69usize, 69usize),
-        (59usize, 61usize, 61usize),
-        (66usize, 68usize, 68usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (20usize, 22usize, Some(22usize)),
+        (27usize, 29usize, Some(29usize)),
+        (34usize, 36usize, Some(36usize)),
+        (41usize, 49usize, Some(49usize)),
+        (46usize, 48usize, Some(48usize)),
+        (54usize, 69usize, Some(69usize)),
+        (59usize, 61usize, Some(61usize)),
+        (66usize, 68usize, Some(68usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -7720,12 +7902,14 @@ fn dense_integer_atomic_leaves_without_lists_compressed_with_query_descendant_se
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -7812,15 +7996,15 @@ fn dense_integer_atomic_leaves_without_lists_compressed_with_query_descendant_se
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (20usize, 22usize, 22usize),
-        (27usize, 29usize, 29usize),
-        (34usize, 36usize, 36usize),
-        (41usize, 49usize, 49usize),
-        (46usize, 48usize, 48usize),
-        (54usize, 69usize, 69usize),
-        (59usize, 61usize, 61usize),
-        (66usize, 68usize, 68usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (20usize, 22usize, Some(22usize)),
+        (27usize, 29usize, Some(29usize)),
+        (34usize, 36usize, Some(36usize)),
+        (41usize, 49usize, Some(49usize)),
+        (46usize, 48usize, Some(48usize)),
+        (54usize, 69usize, Some(69usize)),
+        (59usize, 61usize, Some(61usize)),
+        (66usize, 68usize, Some(68usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -7833,12 +8017,14 @@ fn dense_integer_atomic_leaves_without_lists_compressed_with_query_descendant_se
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -7925,14 +8111,14 @@ fn dense_integer_atomic_leaves_without_lists_compressed_with_query_descendant_se
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (20usize, 22usize, 22usize),
-        (27usize, 29usize, 29usize),
-        (34usize, 36usize, 36usize),
-        (41usize, 49usize, 49usize),
-        (54usize, 69usize, 69usize),
-        (59usize, 61usize, 61usize),
-        (66usize, 68usize, 68usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (20usize, 22usize, Some(22usize)),
+        (27usize, 29usize, Some(29usize)),
+        (34usize, 36usize, Some(36usize)),
+        (41usize, 49usize, Some(49usize)),
+        (54usize, 69usize, Some(69usize)),
+        (59usize, 61usize, Some(61usize)),
+        (66usize, 68usize, Some(68usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -7945,12 +8131,14 @@ fn dense_integer_atomic_leaves_without_lists_compressed_with_query_descendant_se
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -8036,14 +8224,14 @@ fn dense_integer_atomic_leaves_without_lists_compressed_with_query_descendant_se
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (20usize, 22usize, 22usize),
-        (27usize, 29usize, 29usize),
-        (34usize, 36usize, 36usize),
-        (41usize, 49usize, 49usize),
-        (54usize, 69usize, 69usize),
-        (59usize, 61usize, 61usize),
-        (66usize, 68usize, 68usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (20usize, 22usize, Some(22usize)),
+        (27usize, 29usize, Some(29usize)),
+        (34usize, 36usize, Some(36usize)),
+        (41usize, 49usize, Some(49usize)),
+        (54usize, 69usize, Some(69usize)),
+        (59usize, 61usize, Some(61usize)),
+        (66usize, 68usize, Some(68usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -8056,12 +8244,14 @@ fn dense_integer_atomic_leaves_without_lists_compressed_with_query_descendant_se
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -8147,14 +8337,14 @@ fn dense_integer_atomic_leaves_without_lists_compressed_with_query_descendant_se
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (20usize, 22usize, 22usize),
-        (27usize, 29usize, 29usize),
-        (34usize, 36usize, 36usize),
-        (41usize, 49usize, 49usize),
-        (54usize, 69usize, 69usize),
-        (59usize, 61usize, 61usize),
-        (66usize, 68usize, 68usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (20usize, 22usize, Some(22usize)),
+        (27usize, 29usize, Some(29usize)),
+        (34usize, 36usize, Some(36usize)),
+        (41usize, 49usize, Some(49usize)),
+        (54usize, 69usize, Some(69usize)),
+        (59usize, 61usize, Some(61usize)),
+        (66usize, 68usize, Some(68usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -8167,12 +8357,14 @@ fn dense_integer_atomic_leaves_without_lists_compressed_with_query_descendant_se
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -8258,15 +8450,15 @@ fn dense_integer_atomic_leaves_without_lists_with_query_descendant_search_for_a_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (68usize, 70usize, 70usize),
-        (93usize, 95usize, 95usize),
-        (118usize, 120usize, 120usize),
-        (143usize, 190usize, 190usize),
-        (170usize, 172usize, 189usize),
-        (213usize, 289usize, 302usize),
-        (240usize, 242usize, 242usize),
-        (269usize, 271usize, 288usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (68usize, 70usize, Some(70usize)),
+        (93usize, 95usize, Some(95usize)),
+        (118usize, 120usize, Some(120usize)),
+        (143usize, 190usize, Some(190usize)),
+        (170usize, 172usize, Some(189usize)),
+        (213usize, 289usize, Some(302usize)),
+        (240usize, 242usize, Some(242usize)),
+        (269usize, 271usize, Some(288usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -8279,12 +8471,14 @@ fn dense_integer_atomic_leaves_without_lists_with_query_descendant_search_for_a_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -8380,15 +8574,15 @@ fn dense_integer_atomic_leaves_without_lists_with_query_descendant_search_for_a_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (68usize, 70usize, 70usize),
-        (93usize, 95usize, 95usize),
-        (118usize, 120usize, 120usize),
-        (143usize, 190usize, 190usize),
-        (170usize, 172usize, 189usize),
-        (213usize, 289usize, 302usize),
-        (240usize, 242usize, 242usize),
-        (269usize, 271usize, 288usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (68usize, 70usize, Some(70usize)),
+        (93usize, 95usize, Some(95usize)),
+        (118usize, 120usize, Some(120usize)),
+        (143usize, 190usize, Some(190usize)),
+        (170usize, 172usize, Some(189usize)),
+        (213usize, 289usize, Some(302usize)),
+        (240usize, 242usize, Some(242usize)),
+        (269usize, 271usize, Some(288usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -8401,12 +8595,14 @@ fn dense_integer_atomic_leaves_without_lists_with_query_descendant_search_for_a_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -8502,15 +8698,15 @@ fn dense_integer_atomic_leaves_without_lists_with_query_descendant_search_for_a_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (68usize, 70usize, 70usize),
-        (93usize, 95usize, 95usize),
-        (118usize, 120usize, 120usize),
-        (143usize, 190usize, 190usize),
-        (170usize, 172usize, 189usize),
-        (213usize, 289usize, 302usize),
-        (240usize, 242usize, 242usize),
-        (269usize, 271usize, 288usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (68usize, 70usize, Some(70usize)),
+        (93usize, 95usize, Some(95usize)),
+        (118usize, 120usize, Some(120usize)),
+        (143usize, 190usize, Some(190usize)),
+        (170usize, 172usize, Some(189usize)),
+        (213usize, 289usize, Some(302usize)),
+        (240usize, 242usize, Some(242usize)),
+        (269usize, 271usize, Some(288usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -8523,12 +8719,14 @@ fn dense_integer_atomic_leaves_without_lists_with_query_descendant_search_for_a_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -8624,14 +8822,14 @@ fn dense_integer_atomic_leaves_without_lists_with_query_descendant_search_for_a_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (68usize, 70usize, 70usize),
-        (93usize, 95usize, 95usize),
-        (118usize, 120usize, 120usize),
-        (143usize, 190usize, 190usize),
-        (213usize, 289usize, 302usize),
-        (240usize, 242usize, 242usize),
-        (269usize, 271usize, 288usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (68usize, 70usize, Some(70usize)),
+        (93usize, 95usize, Some(95usize)),
+        (118usize, 120usize, Some(120usize)),
+        (143usize, 190usize, Some(190usize)),
+        (213usize, 289usize, Some(302usize)),
+        (240usize, 242usize, Some(242usize)),
+        (269usize, 271usize, Some(288usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -8644,12 +8842,14 @@ fn dense_integer_atomic_leaves_without_lists_with_query_descendant_search_for_a_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -8743,14 +8943,14 @@ fn dense_integer_atomic_leaves_without_lists_with_query_descendant_search_for_a_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (68usize, 70usize, 70usize),
-        (93usize, 95usize, 95usize),
-        (118usize, 120usize, 120usize),
-        (143usize, 190usize, 190usize),
-        (213usize, 289usize, 302usize),
-        (240usize, 242usize, 242usize),
-        (269usize, 271usize, 288usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (68usize, 70usize, Some(70usize)),
+        (93usize, 95usize, Some(95usize)),
+        (118usize, 120usize, Some(120usize)),
+        (143usize, 190usize, Some(190usize)),
+        (213usize, 289usize, Some(302usize)),
+        (240usize, 242usize, Some(242usize)),
+        (269usize, 271usize, Some(288usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -8763,12 +8963,14 @@ fn dense_integer_atomic_leaves_without_lists_with_query_descendant_search_for_a_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -8862,14 +9064,14 @@ fn dense_integer_atomic_leaves_without_lists_with_query_descendant_search_for_a_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (68usize, 70usize, 70usize),
-        (93usize, 95usize, 95usize),
-        (118usize, 120usize, 120usize),
-        (143usize, 190usize, 190usize),
-        (213usize, 289usize, 302usize),
-        (240usize, 242usize, 242usize),
-        (269usize, 271usize, 288usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (68usize, 70usize, Some(70usize)),
+        (93usize, 95usize, Some(95usize)),
+        (118usize, 120usize, Some(120usize)),
+        (143usize, 190usize, Some(190usize)),
+        (213usize, 289usize, Some(302usize)),
+        (240usize, 242usize, Some(242usize)),
+        (269usize, 271usize, Some(288usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -8882,12 +9084,14 @@ fn dense_integer_atomic_leaves_without_lists_with_query_descendant_search_for_a_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -8981,7 +9185,7 @@ fn empty_array_root_compressed_with_query_select_any_descendant_there_are_none_w
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -8993,12 +9197,14 @@ fn empty_array_root_compressed_with_query_select_any_descendant_there_are_none_w
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -9072,7 +9278,7 @@ fn empty_array_root_compressed_with_query_select_any_descendant_there_are_none_w
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -9084,12 +9290,14 @@ fn empty_array_root_compressed_with_query_select_any_descendant_there_are_none_w
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -9163,7 +9371,7 @@ fn empty_array_root_compressed_with_query_select_any_descendant_there_are_none_w
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -9175,12 +9383,14 @@ fn empty_array_root_compressed_with_query_select_any_descendant_there_are_none_w
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -9254,7 +9464,7 @@ fn empty_array_root_compressed_with_query_select_any_item_there_are_none_with_bu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -9266,12 +9476,14 @@ fn empty_array_root_compressed_with_query_select_any_item_there_are_none_with_bu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -9345,7 +9557,7 @@ fn empty_array_root_compressed_with_query_select_any_item_there_are_none_with_mm
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -9357,12 +9569,14 @@ fn empty_array_root_compressed_with_query_select_any_item_there_are_none_with_mm
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -9436,7 +9650,7 @@ fn empty_array_root_compressed_with_query_select_any_item_there_are_none_with_ow
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -9448,12 +9662,14 @@ fn empty_array_root_compressed_with_query_select_any_item_there_are_none_with_ow
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -9527,7 +9743,7 @@ fn empty_array_root_compressed_with_query_select_the_first_item_which_does_not_e
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -9539,12 +9755,14 @@ fn empty_array_root_compressed_with_query_select_the_first_item_which_does_not_e
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -9618,7 +9836,7 @@ fn empty_array_root_compressed_with_query_select_the_first_item_which_does_not_e
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -9630,12 +9848,14 @@ fn empty_array_root_compressed_with_query_select_the_first_item_which_does_not_e
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -9709,7 +9929,7 @@ fn empty_array_root_compressed_with_query_select_the_first_item_which_does_not_e
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -9721,12 +9941,14 @@ fn empty_array_root_compressed_with_query_select_the_first_item_which_does_not_e
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -9800,7 +10022,7 @@ fn empty_array_root_compressed_with_query_select_the_root_empty_query_with_buffe
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -9812,12 +10034,14 @@ fn empty_array_root_compressed_with_query_select_the_root_empty_query_with_buffe
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -9891,7 +10115,7 @@ fn empty_array_root_compressed_with_query_select_the_root_empty_query_with_mmap_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -9903,12 +10127,14 @@ fn empty_array_root_compressed_with_query_select_the_root_empty_query_with_mmap_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -9982,7 +10208,7 @@ fn empty_array_root_compressed_with_query_select_the_root_empty_query_with_owned
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -9994,12 +10220,14 @@ fn empty_array_root_compressed_with_query_select_the_root_empty_query_with_owned
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -10073,7 +10301,7 @@ fn empty_array_root_compressed_with_query_select_the_root_with_buffered_input_an
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10085,12 +10313,14 @@ fn empty_array_root_compressed_with_query_select_the_root_with_buffered_input_an
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -10164,7 +10394,7 @@ fn empty_array_root_compressed_with_query_select_the_root_with_mmap_input_and_ap
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10176,12 +10406,14 @@ fn empty_array_root_compressed_with_query_select_the_root_with_mmap_input_and_ap
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -10255,7 +10487,7 @@ fn empty_array_root_compressed_with_query_select_the_root_with_owned_bytes_and_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10267,12 +10499,14 @@ fn empty_array_root_compressed_with_query_select_the_root_with_owned_bytes_and_a
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -10346,7 +10580,7 @@ fn empty_array_root_with_query_select_any_descendant_there_are_none_with_buffere
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10358,12 +10592,14 @@ fn empty_array_root_with_query_select_any_descendant_there_are_none_with_buffere
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -10437,7 +10673,7 @@ fn empty_array_root_with_query_select_any_descendant_there_are_none_with_mmap_in
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10449,12 +10685,14 @@ fn empty_array_root_with_query_select_any_descendant_there_are_none_with_mmap_in
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -10528,7 +10766,7 @@ fn empty_array_root_with_query_select_any_descendant_there_are_none_with_owned_b
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10540,12 +10778,14 @@ fn empty_array_root_with_query_select_any_descendant_there_are_none_with_owned_b
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -10619,7 +10859,7 @@ fn empty_array_root_with_query_select_any_item_there_are_none_with_buffered_inpu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10631,12 +10871,14 @@ fn empty_array_root_with_query_select_any_item_there_are_none_with_buffered_inpu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -10710,7 +10952,7 @@ fn empty_array_root_with_query_select_any_item_there_are_none_with_mmap_input_an
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10722,12 +10964,14 @@ fn empty_array_root_with_query_select_any_item_there_are_none_with_mmap_input_an
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -10801,7 +11045,7 @@ fn empty_array_root_with_query_select_any_item_there_are_none_with_owned_bytes_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10813,12 +11057,14 @@ fn empty_array_root_with_query_select_any_item_there_are_none_with_owned_bytes_a
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -10892,7 +11138,7 @@ fn empty_array_root_with_query_select_the_first_item_which_does_not_exist_with_b
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10904,12 +11150,14 @@ fn empty_array_root_with_query_select_the_first_item_which_does_not_exist_with_b
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -10983,7 +11231,7 @@ fn empty_array_root_with_query_select_the_first_item_which_does_not_exist_with_m
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -10995,12 +11243,14 @@ fn empty_array_root_with_query_select_the_first_item_which_does_not_exist_with_m
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -11074,7 +11324,7 @@ fn empty_array_root_with_query_select_the_first_item_which_does_not_exist_with_o
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11086,12 +11336,14 @@ fn empty_array_root_with_query_select_the_first_item_which_does_not_exist_with_o
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -11165,7 +11417,7 @@ fn empty_array_root_with_query_select_the_root_empty_query_with_buffered_input_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11177,12 +11429,14 @@ fn empty_array_root_with_query_select_the_root_empty_query_with_buffered_input_a
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -11256,7 +11510,7 @@ fn empty_array_root_with_query_select_the_root_empty_query_with_mmap_input_and_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11268,12 +11522,14 @@ fn empty_array_root_with_query_select_the_root_empty_query_with_mmap_input_and_a
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -11347,7 +11603,7 @@ fn empty_array_root_with_query_select_the_root_empty_query_with_owned_bytes_and_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11359,12 +11615,14 @@ fn empty_array_root_with_query_select_the_root_empty_query_with_owned_bytes_and_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -11438,7 +11696,7 @@ fn empty_array_root_with_query_select_the_root_with_buffered_input_and_approx_sp
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11450,12 +11708,14 @@ fn empty_array_root_with_query_select_the_root_with_buffered_input_and_approx_sp
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -11529,7 +11789,7 @@ fn empty_array_root_with_query_select_the_root_with_mmap_input_and_approx_span_r
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11541,12 +11801,14 @@ fn empty_array_root_with_query_select_the_root_with_mmap_input_and_approx_span_r
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -11620,7 +11882,7 @@ fn empty_array_root_with_query_select_the_root_with_owned_bytes_and_approx_span_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11632,12 +11894,14 @@ fn empty_array_root_with_query_select_the_root_with_owned_bytes_and_approx_span_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -11711,7 +11975,7 @@ fn empty_document_compressed_with_query_select_the_root_empty_query_with_buffere
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11723,12 +11987,14 @@ fn empty_document_compressed_with_query_select_the_root_empty_query_with_buffere
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -11802,7 +12068,7 @@ fn empty_document_compressed_with_query_select_the_root_empty_query_with_mmap_in
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11814,12 +12080,14 @@ fn empty_document_compressed_with_query_select_the_root_empty_query_with_mmap_in
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -11893,7 +12161,7 @@ fn empty_document_compressed_with_query_select_the_root_empty_query_with_owned_b
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11905,12 +12173,14 @@ fn empty_document_compressed_with_query_select_the_root_empty_query_with_owned_b
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -11984,7 +12254,7 @@ fn empty_document_compressed_with_query_select_the_root_with_buffered_input_and_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -11996,12 +12266,14 @@ fn empty_document_compressed_with_query_select_the_root_with_buffered_input_and_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -12075,7 +12347,7 @@ fn empty_document_compressed_with_query_select_the_root_with_mmap_input_and_appr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -12087,12 +12359,14 @@ fn empty_document_compressed_with_query_select_the_root_with_mmap_input_and_appr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -12166,7 +12440,7 @@ fn empty_document_compressed_with_query_select_the_root_with_owned_bytes_and_app
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -12178,12 +12452,14 @@ fn empty_document_compressed_with_query_select_the_root_with_owned_bytes_and_app
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -12257,7 +12533,7 @@ fn empty_document_with_query_select_the_root_empty_query_with_buffered_input_and
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -12269,12 +12545,14 @@ fn empty_document_with_query_select_the_root_empty_query_with_buffered_input_and
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -12348,7 +12626,7 @@ fn empty_document_with_query_select_the_root_empty_query_with_mmap_input_and_app
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -12360,12 +12638,14 @@ fn empty_document_with_query_select_the_root_empty_query_with_mmap_input_and_app
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -12439,7 +12719,7 @@ fn empty_document_with_query_select_the_root_empty_query_with_owned_bytes_and_ap
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -12451,12 +12731,14 @@ fn empty_document_with_query_select_the_root_empty_query_with_owned_bytes_and_ap
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -12530,7 +12812,7 @@ fn empty_document_with_query_select_the_root_with_buffered_input_and_approx_span
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -12542,12 +12824,14 @@ fn empty_document_with_query_select_the_root_with_buffered_input_and_approx_span
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -12621,7 +12905,7 @@ fn empty_document_with_query_select_the_root_with_mmap_input_and_approx_span_res
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -12633,12 +12917,14 @@ fn empty_document_with_query_select_the_root_with_mmap_input_and_approx_span_res
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -12712,7 +12998,7 @@ fn empty_document_with_query_select_the_root_with_owned_bytes_and_approx_span_re
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -12724,12 +13010,14 @@ fn empty_document_with_query_select_the_root_with_owned_bytes_and_approx_span_re
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -12803,7 +13091,7 @@ fn empty_json_keys_compressed_with_query_select_the_empty_key_by_descendant_with
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(4usize, 12usize, 12usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(4usize, 12usize, Some(12usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -12815,12 +13103,14 @@ fn empty_json_keys_compressed_with_query_select_the_empty_key_by_descendant_with
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -12894,7 +13184,7 @@ fn empty_json_keys_compressed_with_query_select_the_empty_key_by_descendant_with
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(4usize, 12usize, 12usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(4usize, 12usize, Some(12usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -12906,12 +13196,14 @@ fn empty_json_keys_compressed_with_query_select_the_empty_key_by_descendant_with
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -12985,7 +13277,7 @@ fn empty_json_keys_compressed_with_query_select_the_empty_key_by_descendant_with
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(4usize, 12usize, 12usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(4usize, 12usize, Some(12usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -12997,12 +13289,14 @@ fn empty_json_keys_compressed_with_query_select_the_empty_key_by_descendant_with
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -13076,7 +13370,7 @@ fn empty_json_keys_compressed_with_query_select_the_empty_key_with_buffered_inpu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(4usize, 12usize, 12usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(4usize, 12usize, Some(12usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -13088,12 +13382,14 @@ fn empty_json_keys_compressed_with_query_select_the_empty_key_with_buffered_inpu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -13167,7 +13463,7 @@ fn empty_json_keys_compressed_with_query_select_the_empty_key_with_mmap_input_an
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(4usize, 12usize, 12usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(4usize, 12usize, Some(12usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -13179,12 +13475,14 @@ fn empty_json_keys_compressed_with_query_select_the_empty_key_with_mmap_input_an
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -13258,7 +13556,7 @@ fn empty_json_keys_compressed_with_query_select_the_empty_key_with_owned_bytes_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(4usize, 12usize, 12usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(4usize, 12usize, Some(12usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -13270,12 +13568,14 @@ fn empty_json_keys_compressed_with_query_select_the_empty_key_with_owned_bytes_a
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -13349,7 +13649,7 @@ fn empty_json_keys_with_query_select_the_empty_key_by_descendant_with_buffered_i
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(8usize, 16usize, 16usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(8usize, 16usize, Some(16usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -13361,12 +13661,14 @@ fn empty_json_keys_with_query_select_the_empty_key_by_descendant_with_buffered_i
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -13440,7 +13742,7 @@ fn empty_json_keys_with_query_select_the_empty_key_by_descendant_with_mmap_input
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(8usize, 16usize, 16usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(8usize, 16usize, Some(16usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -13452,12 +13754,14 @@ fn empty_json_keys_with_query_select_the_empty_key_by_descendant_with_mmap_input
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -13531,7 +13835,7 @@ fn empty_json_keys_with_query_select_the_empty_key_by_descendant_with_owned_byte
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(8usize, 16usize, 16usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(8usize, 16usize, Some(16usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -13543,12 +13847,14 @@ fn empty_json_keys_with_query_select_the_empty_key_by_descendant_with_owned_byte
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -13622,7 +13928,7 @@ fn empty_json_keys_with_query_select_the_empty_key_with_buffered_input_and_appro
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(8usize, 16usize, 16usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(8usize, 16usize, Some(16usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -13634,12 +13940,14 @@ fn empty_json_keys_with_query_select_the_empty_key_with_buffered_input_and_appro
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -13713,7 +14021,7 @@ fn empty_json_keys_with_query_select_the_empty_key_with_mmap_input_and_approx_sp
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(8usize, 16usize, 16usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(8usize, 16usize, Some(16usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -13725,12 +14033,14 @@ fn empty_json_keys_with_query_select_the_empty_key_with_mmap_input_and_approx_sp
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -13804,7 +14114,7 @@ fn empty_json_keys_with_query_select_the_empty_key_with_owned_bytes_and_approx_s
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(8usize, 16usize, 16usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(8usize, 16usize, Some(16usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -13816,12 +14126,14 @@ fn empty_json_keys_with_query_select_the_empty_key_with_owned_bytes_and_approx_s
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -13895,7 +14207,7 @@ fn empty_object_root_compressed_with_query_select_any_child_there_are_none_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -13907,12 +14219,14 @@ fn empty_object_root_compressed_with_query_select_any_child_there_are_none_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -13986,7 +14300,7 @@ fn empty_object_root_compressed_with_query_select_any_child_there_are_none_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -13998,12 +14312,14 @@ fn empty_object_root_compressed_with_query_select_any_child_there_are_none_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -14077,7 +14393,7 @@ fn empty_object_root_compressed_with_query_select_any_child_there_are_none_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14089,12 +14405,14 @@ fn empty_object_root_compressed_with_query_select_any_child_there_are_none_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -14168,7 +14486,7 @@ fn empty_object_root_compressed_with_query_select_any_descendant_there_are_none_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14180,12 +14498,14 @@ fn empty_object_root_compressed_with_query_select_any_descendant_there_are_none_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -14259,7 +14579,7 @@ fn empty_object_root_compressed_with_query_select_any_descendant_there_are_none_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14271,12 +14591,14 @@ fn empty_object_root_compressed_with_query_select_any_descendant_there_are_none_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -14350,7 +14672,7 @@ fn empty_object_root_compressed_with_query_select_any_descendant_there_are_none_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14362,12 +14684,14 @@ fn empty_object_root_compressed_with_query_select_any_descendant_there_are_none_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -14441,7 +14765,7 @@ fn empty_object_root_compressed_with_query_select_the_child_named_a_which_does_n
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14453,12 +14777,14 @@ fn empty_object_root_compressed_with_query_select_the_child_named_a_which_does_n
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -14532,7 +14858,7 @@ fn empty_object_root_compressed_with_query_select_the_child_named_a_which_does_n
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14544,12 +14870,14 @@ fn empty_object_root_compressed_with_query_select_the_child_named_a_which_does_n
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -14623,7 +14951,7 @@ fn empty_object_root_compressed_with_query_select_the_child_named_a_which_does_n
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14635,12 +14963,14 @@ fn empty_object_root_compressed_with_query_select_the_child_named_a_which_does_n
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -14714,7 +15044,7 @@ fn empty_object_root_compressed_with_query_select_the_root_empty_query_with_buff
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14726,12 +15056,14 @@ fn empty_object_root_compressed_with_query_select_the_root_empty_query_with_buff
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -14805,7 +15137,7 @@ fn empty_object_root_compressed_with_query_select_the_root_empty_query_with_mmap
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14817,12 +15149,14 @@ fn empty_object_root_compressed_with_query_select_the_root_empty_query_with_mmap
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -14896,7 +15230,7 @@ fn empty_object_root_compressed_with_query_select_the_root_empty_query_with_owne
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14908,12 +15242,14 @@ fn empty_object_root_compressed_with_query_select_the_root_empty_query_with_owne
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -14987,7 +15323,7 @@ fn empty_object_root_compressed_with_query_select_the_root_with_buffered_input_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -14999,12 +15335,14 @@ fn empty_object_root_compressed_with_query_select_the_root_with_buffered_input_a
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -15078,7 +15416,7 @@ fn empty_object_root_compressed_with_query_select_the_root_with_mmap_input_and_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -15090,12 +15428,14 @@ fn empty_object_root_compressed_with_query_select_the_root_with_mmap_input_and_a
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -15169,7 +15509,7 @@ fn empty_object_root_compressed_with_query_select_the_root_with_owned_bytes_and_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -15181,12 +15521,14 @@ fn empty_object_root_compressed_with_query_select_the_root_with_owned_bytes_and_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -15260,7 +15602,7 @@ fn empty_object_root_with_query_select_any_child_there_are_none_with_buffered_in
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -15272,12 +15614,14 @@ fn empty_object_root_with_query_select_any_child_there_are_none_with_buffered_in
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -15351,7 +15695,7 @@ fn empty_object_root_with_query_select_any_child_there_are_none_with_mmap_input_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -15363,12 +15707,14 @@ fn empty_object_root_with_query_select_any_child_there_are_none_with_mmap_input_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -15442,7 +15788,7 @@ fn empty_object_root_with_query_select_any_child_there_are_none_with_owned_bytes
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -15454,12 +15800,14 @@ fn empty_object_root_with_query_select_any_child_there_are_none_with_owned_bytes
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -15533,7 +15881,7 @@ fn empty_object_root_with_query_select_any_descendant_there_are_none_with_buffer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -15545,12 +15893,14 @@ fn empty_object_root_with_query_select_any_descendant_there_are_none_with_buffer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -15624,7 +15974,7 @@ fn empty_object_root_with_query_select_any_descendant_there_are_none_with_mmap_i
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -15636,12 +15986,14 @@ fn empty_object_root_with_query_select_any_descendant_there_are_none_with_mmap_i
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -15715,7 +16067,7 @@ fn empty_object_root_with_query_select_any_descendant_there_are_none_with_owned_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -15727,12 +16079,14 @@ fn empty_object_root_with_query_select_any_descendant_there_are_none_with_owned_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -15806,7 +16160,7 @@ fn empty_object_root_with_query_select_the_child_named_a_which_does_not_exist_wi
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -15818,12 +16172,14 @@ fn empty_object_root_with_query_select_the_child_named_a_which_does_not_exist_wi
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -15897,7 +16253,7 @@ fn empty_object_root_with_query_select_the_child_named_a_which_does_not_exist_wi
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -15909,12 +16265,14 @@ fn empty_object_root_with_query_select_the_child_named_a_which_does_not_exist_wi
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -15988,7 +16346,7 @@ fn empty_object_root_with_query_select_the_child_named_a_which_does_not_exist_wi
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16000,12 +16358,14 @@ fn empty_object_root_with_query_select_the_child_named_a_which_does_not_exist_wi
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -16079,7 +16439,7 @@ fn empty_object_root_with_query_select_the_root_empty_query_with_buffered_input_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16091,12 +16451,14 @@ fn empty_object_root_with_query_select_the_root_empty_query_with_buffered_input_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -16170,7 +16532,7 @@ fn empty_object_root_with_query_select_the_root_empty_query_with_mmap_input_and_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16182,12 +16544,14 @@ fn empty_object_root_with_query_select_the_root_empty_query_with_mmap_input_and_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -16261,7 +16625,7 @@ fn empty_object_root_with_query_select_the_root_empty_query_with_owned_bytes_and
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16273,12 +16637,14 @@ fn empty_object_root_with_query_select_the_root_empty_query_with_owned_bytes_and
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -16352,7 +16718,7 @@ fn empty_object_root_with_query_select_the_root_with_buffered_input_and_approx_s
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16364,12 +16730,14 @@ fn empty_object_root_with_query_select_the_root_with_buffered_input_and_approx_s
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -16443,7 +16811,7 @@ fn empty_object_root_with_query_select_the_root_with_mmap_input_and_approx_span_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16455,12 +16823,14 @@ fn empty_object_root_with_query_select_the_root_with_mmap_input_and_approx_span_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -16534,7 +16904,7 @@ fn empty_object_root_with_query_select_the_root_with_owned_bytes_and_approx_span
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16546,12 +16916,14 @@ fn empty_object_root_with_query_select_the_root_with_owned_bytes_and_approx_span
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -16625,11 +16997,11 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (151usize, 179usize, 179usize),
-        (198usize, 226usize, 226usize),
-        (341usize, 369usize, 369usize),
-        (388usize, 416usize, 416usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (151usize, 179usize, Some(179usize)),
+        (198usize, 226usize, Some(226usize)),
+        (341usize, 369usize, Some(369usize)),
+        (388usize, 416usize, Some(416usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -16642,12 +17014,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -16735,11 +17109,11 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (151usize, 179usize, 179usize),
-        (198usize, 226usize, 226usize),
-        (341usize, 369usize, 369usize),
-        (388usize, 416usize, 416usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (151usize, 179usize, Some(179usize)),
+        (198usize, 226usize, Some(226usize)),
+        (341usize, 369usize, Some(369usize)),
+        (388usize, 416usize, Some(416usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -16752,12 +17126,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -16845,11 +17221,11 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (151usize, 179usize, 179usize),
-        (198usize, 226usize, 226usize),
-        (341usize, 369usize, 369usize),
-        (388usize, 416usize, 416usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (151usize, 179usize, Some(179usize)),
+        (198usize, 226usize, Some(226usize)),
+        (341usize, 369usize, Some(369usize)),
+        (388usize, 416usize, Some(416usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -16862,12 +17238,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -16955,7 +17333,10 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(151usize, 179usize, 179usize), (341usize, 369usize, 369usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (151usize, 179usize, Some(179usize)),
+        (341usize, 369usize, Some(369usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -16967,12 +17348,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -17046,7 +17429,10 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(151usize, 179usize, 179usize), (341usize, 369usize, 369usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (151usize, 179usize, Some(179usize)),
+        (341usize, 369usize, Some(369usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -17058,12 +17444,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -17137,7 +17525,10 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(151usize, 179usize, 179usize), (341usize, 369usize, 369usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (151usize, 179usize, Some(179usize)),
+        (341usize, 369usize, Some(369usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -17149,12 +17540,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -17228,7 +17621,10 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(151usize, 179usize, 179usize), (341usize, 369usize, 369usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (151usize, 179usize, Some(179usize)),
+        (341usize, 369usize, Some(369usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -17240,12 +17636,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -17319,7 +17717,10 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(151usize, 179usize, 179usize), (341usize, 369usize, 369usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (151usize, 179usize, Some(179usize)),
+        (341usize, 369usize, Some(369usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -17331,12 +17732,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -17410,7 +17813,10 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(151usize, 179usize, 179usize), (341usize, 369usize, 369usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (151usize, 179usize, Some(179usize)),
+        (341usize, 369usize, Some(369usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -17422,12 +17828,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -17501,15 +17909,15 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (16usize, 54usize, 54usize),
-        (90usize, 122usize, 122usize),
-        (151usize, 179usize, 179usize),
-        (198usize, 226usize, 226usize),
-        (267usize, 295usize, 295usize),
-        (341usize, 369usize, 369usize),
-        (388usize, 416usize, 416usize),
-        (426usize, 454usize, 454usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (16usize, 54usize, Some(54usize)),
+        (90usize, 122usize, Some(122usize)),
+        (151usize, 179usize, Some(179usize)),
+        (198usize, 226usize, Some(226usize)),
+        (267usize, 295usize, Some(295usize)),
+        (341usize, 369usize, Some(369usize)),
+        (388usize, 416usize, Some(416usize)),
+        (426usize, 454usize, Some(454usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -17522,12 +17930,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -17623,15 +18033,15 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (16usize, 54usize, 54usize),
-        (90usize, 122usize, 122usize),
-        (151usize, 179usize, 179usize),
-        (198usize, 226usize, 226usize),
-        (267usize, 295usize, 295usize),
-        (341usize, 369usize, 369usize),
-        (388usize, 416usize, 416usize),
-        (426usize, 454usize, 454usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (16usize, 54usize, Some(54usize)),
+        (90usize, 122usize, Some(122usize)),
+        (151usize, 179usize, Some(179usize)),
+        (198usize, 226usize, Some(226usize)),
+        (267usize, 295usize, Some(295usize)),
+        (341usize, 369usize, Some(369usize)),
+        (388usize, 416usize, Some(416usize)),
+        (426usize, 454usize, Some(454usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -17644,12 +18054,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -17745,15 +18157,15 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (16usize, 54usize, 54usize),
-        (90usize, 122usize, 122usize),
-        (151usize, 179usize, 179usize),
-        (198usize, 226usize, 226usize),
-        (267usize, 295usize, 295usize),
-        (341usize, 369usize, 369usize),
-        (388usize, 416usize, 416usize),
-        (426usize, 454usize, 454usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (16usize, 54usize, Some(54usize)),
+        (90usize, 122usize, Some(122usize)),
+        (151usize, 179usize, Some(179usize)),
+        (198usize, 226usize, Some(226usize)),
+        (267usize, 295usize, Some(295usize)),
+        (341usize, 369usize, Some(369usize)),
+        (388usize, 416usize, Some(416usize)),
+        (426usize, 454usize, Some(454usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -17766,12 +18178,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -17867,7 +18281,7 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(426usize, 454usize, 454usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(426usize, 454usize, Some(454usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -17879,12 +18293,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -17958,7 +18374,7 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(426usize, 454usize, 454usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(426usize, 454usize, Some(454usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -17970,12 +18386,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -18049,7 +18467,7 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(426usize, 454usize, 454usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(426usize, 454usize, Some(454usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -18061,12 +18479,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_compr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -18140,11 +18560,11 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (323usize, 351usize, 372usize),
-        (473usize, 501usize, 522usize),
-        (883usize, 911usize, 928usize),
-        (1013usize, 1041usize, 1058usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (323usize, 351usize, Some(372usize)),
+        (473usize, 501usize, Some(522usize)),
+        (883usize, 911usize, Some(928usize)),
+        (1013usize, 1041usize, Some(1058usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -18157,12 +18577,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -18250,11 +18672,11 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (323usize, 351usize, 372usize),
-        (473usize, 501usize, 522usize),
-        (883usize, 911usize, 928usize),
-        (1013usize, 1041usize, 1058usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (323usize, 351usize, Some(372usize)),
+        (473usize, 501usize, Some(522usize)),
+        (883usize, 911usize, Some(928usize)),
+        (1013usize, 1041usize, Some(1058usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -18267,12 +18689,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -18360,11 +18784,11 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (323usize, 351usize, 372usize),
-        (473usize, 501usize, 522usize),
-        (883usize, 911usize, 928usize),
-        (1013usize, 1041usize, 1058usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (323usize, 351usize, Some(372usize)),
+        (473usize, 501usize, Some(522usize)),
+        (883usize, 911usize, Some(928usize)),
+        (1013usize, 1041usize, Some(1058usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -18377,12 +18801,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -18470,7 +18896,10 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(323usize, 351usize, 372usize), (883usize, 911usize, 928usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (323usize, 351usize, Some(372usize)),
+        (883usize, 911usize, Some(928usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -18482,12 +18911,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -18561,7 +18992,10 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(323usize, 351usize, 372usize), (883usize, 911usize, 928usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (323usize, 351usize, Some(372usize)),
+        (883usize, 911usize, Some(928usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -18573,12 +19007,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -18652,7 +19088,10 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(323usize, 351usize, 372usize), (883usize, 911usize, 928usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (323usize, 351usize, Some(372usize)),
+        (883usize, 911usize, Some(928usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -18664,12 +19103,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -18743,7 +19184,10 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(323usize, 351usize, 372usize), (883usize, 911usize, 928usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (323usize, 351usize, Some(372usize)),
+        (883usize, 911usize, Some(928usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -18755,12 +19199,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -18834,7 +19280,10 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(323usize, 351usize, 372usize), (883usize, 911usize, 928usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (323usize, 351usize, Some(372usize)),
+        (883usize, 911usize, Some(928usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -18846,12 +19295,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -18925,7 +19376,10 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(323usize, 351usize, 372usize), (883usize, 911usize, 928usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (323usize, 351usize, Some(372usize)),
+        (883usize, 911usize, Some(928usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -18937,12 +19391,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -19016,15 +19472,15 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (45usize, 83usize, 92usize),
-        (170usize, 202usize, 215usize),
-        (323usize, 351usize, 372usize),
-        (473usize, 501usize, 522usize),
-        (672usize, 700usize, 721usize),
-        (883usize, 911usize, 928usize),
-        (1013usize, 1041usize, 1058usize),
-        (1100usize, 1128usize, 1133usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (45usize, 83usize, Some(92usize)),
+        (170usize, 202usize, Some(215usize)),
+        (323usize, 351usize, Some(372usize)),
+        (473usize, 501usize, Some(522usize)),
+        (672usize, 700usize, Some(721usize)),
+        (883usize, 911usize, Some(928usize)),
+        (1013usize, 1041usize, Some(1058usize)),
+        (1100usize, 1128usize, Some(1133usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -19037,12 +19493,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -19138,15 +19596,15 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (45usize, 83usize, 92usize),
-        (170usize, 202usize, 215usize),
-        (323usize, 351usize, 372usize),
-        (473usize, 501usize, 522usize),
-        (672usize, 700usize, 721usize),
-        (883usize, 911usize, 928usize),
-        (1013usize, 1041usize, 1058usize),
-        (1100usize, 1128usize, 1133usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (45usize, 83usize, Some(92usize)),
+        (170usize, 202usize, Some(215usize)),
+        (323usize, 351usize, Some(372usize)),
+        (473usize, 501usize, Some(522usize)),
+        (672usize, 700usize, Some(721usize)),
+        (883usize, 911usize, Some(928usize)),
+        (1013usize, 1041usize, Some(1058usize)),
+        (1100usize, 1128usize, Some(1133usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -19159,12 +19617,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -19260,15 +19720,15 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (45usize, 83usize, 92usize),
-        (170usize, 202usize, 215usize),
-        (323usize, 351usize, 372usize),
-        (473usize, 501usize, 522usize),
-        (672usize, 700usize, 721usize),
-        (883usize, 911usize, 928usize),
-        (1013usize, 1041usize, 1058usize),
-        (1100usize, 1128usize, 1133usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (45usize, 83usize, Some(92usize)),
+        (170usize, 202usize, Some(215usize)),
+        (323usize, 351usize, Some(372usize)),
+        (473usize, 501usize, Some(522usize)),
+        (672usize, 700usize, Some(721usize)),
+        (883usize, 911usize, Some(928usize)),
+        (1013usize, 1041usize, Some(1058usize)),
+        (1100usize, 1128usize, Some(1133usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -19281,12 +19741,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -19382,7 +19844,7 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(1100usize, 1128usize, 1133usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(1100usize, 1128usize, Some(1133usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -19394,12 +19856,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -19473,7 +19937,7 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(1100usize, 1128usize, 1133usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(1100usize, 1128usize, Some(1133usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -19485,12 +19949,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -19564,7 +20030,7 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(1100usize, 1128usize, 1133usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(1100usize, 1128usize, Some(1133usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -19576,12 +20042,14 @@ fn extract_from_twitter_json_containing_urls_with_multiple_escaped_slashes_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -19655,7 +20123,7 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_compressed_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(12usize, 14usize, 14usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(12usize, 14usize, Some(14usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -19667,12 +20135,14 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_compressed_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -19746,7 +20216,7 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_compressed_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(12usize, 14usize, 14usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(12usize, 14usize, Some(14usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -19758,12 +20228,14 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_compressed_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -19837,7 +20309,7 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_compressed_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(12usize, 14usize, 14usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(12usize, 14usize, Some(14usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -19849,12 +20321,14 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_compressed_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -19928,7 +20402,7 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_compressed_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(19usize, 21usize, 21usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(19usize, 21usize, Some(21usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -19940,12 +20414,14 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_compressed_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -20019,7 +20495,7 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_compressed_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(19usize, 21usize, 21usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(19usize, 21usize, Some(21usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -20031,12 +20507,14 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_compressed_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -20110,7 +20588,7 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_compressed_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(19usize, 21usize, 21usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(19usize, 21usize, Some(21usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -20122,12 +20600,14 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_compressed_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -20201,7 +20681,7 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_with_query_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(28usize, 30usize, 30usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(28usize, 30usize, Some(30usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -20213,12 +20693,14 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_with_query_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -20292,7 +20774,7 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_with_query_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(28usize, 30usize, 30usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(28usize, 30usize, Some(30usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -20304,12 +20786,14 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_with_query_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -20383,7 +20867,7 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_with_query_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(28usize, 30usize, 30usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(28usize, 30usize, Some(30usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -20395,12 +20879,14 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_with_query_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -20474,7 +20960,7 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_with_query_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(45usize, 47usize, 53usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(45usize, 47usize, Some(53usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -20486,12 +20972,14 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_with_query_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -20565,7 +21053,7 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_with_query_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(45usize, 47usize, 53usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(45usize, 47usize, Some(53usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -20577,12 +21065,14 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_with_query_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -20656,7 +21146,7 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_with_query_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(45usize, 47usize, 53usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(45usize, 47usize, Some(53usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -20668,12 +21158,14 @@ fn label_b_and_b_with_escaped_quote_to_trick_naive_string_comparison_with_query_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -22772,7 +23264,7 @@ fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_e
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -22784,12 +23276,14 @@ fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_e
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -22863,7 +23357,7 @@ fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_e
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -22875,12 +23369,14 @@ fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_e
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -22954,7 +23450,7 @@ fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_e
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -22966,12 +23462,14 @@ fn list_with_an_empty_string_compressed_with_query_descendant_search_for_a_key_e
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -23045,7 +23543,7 @@ fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -23057,12 +23555,14 @@ fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -23136,7 +23636,7 @@ fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -23148,12 +23648,14 @@ fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -23227,7 +23729,7 @@ fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -23239,12 +23741,14 @@ fn list_with_an_empty_string_with_query_descendant_search_for_a_key_equal_to_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -23318,10 +23822,10 @@ fn list_with_mixed_atomic_integers_and_objects_compressed_with_query_select_all_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (6usize, 8usize, 8usize),
-        (9usize, 17usize, 17usize),
-        (18usize, 20usize, 20usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (6usize, 8usize, Some(8usize)),
+        (9usize, 17usize, Some(17usize)),
+        (18usize, 20usize, Some(20usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -23334,12 +23838,14 @@ fn list_with_mixed_atomic_integers_and_objects_compressed_with_query_select_all_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -23413,10 +23919,10 @@ fn list_with_mixed_atomic_integers_and_objects_compressed_with_query_select_all_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (6usize, 8usize, 8usize),
-        (9usize, 17usize, 17usize),
-        (18usize, 20usize, 20usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (6usize, 8usize, Some(8usize)),
+        (9usize, 17usize, Some(17usize)),
+        (18usize, 20usize, Some(20usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -23429,12 +23935,14 @@ fn list_with_mixed_atomic_integers_and_objects_compressed_with_query_select_all_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -23508,10 +24016,10 @@ fn list_with_mixed_atomic_integers_and_objects_compressed_with_query_select_all_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (6usize, 8usize, 8usize),
-        (9usize, 17usize, 17usize),
-        (18usize, 20usize, 20usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (6usize, 8usize, Some(8usize)),
+        (9usize, 17usize, Some(17usize)),
+        (18usize, 20usize, Some(20usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -23524,12 +24032,14 @@ fn list_with_mixed_atomic_integers_and_objects_compressed_with_query_select_all_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -23603,10 +24113,10 @@ fn list_with_mixed_atomic_integers_and_objects_with_query_select_all_elements_on
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (15usize, 17usize, 17usize),
-        (23usize, 44usize, 44usize),
-        (50usize, 52usize, 55usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (15usize, 17usize, Some(17usize)),
+        (23usize, 44usize, Some(44usize)),
+        (50usize, 52usize, Some(55usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -23619,12 +24129,14 @@ fn list_with_mixed_atomic_integers_and_objects_with_query_select_all_elements_on
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -23698,10 +24210,10 @@ fn list_with_mixed_atomic_integers_and_objects_with_query_select_all_elements_on
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (15usize, 17usize, 17usize),
-        (23usize, 44usize, 44usize),
-        (50usize, 52usize, 55usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (15usize, 17usize, Some(17usize)),
+        (23usize, 44usize, Some(44usize)),
+        (50usize, 52usize, Some(55usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -23714,12 +24226,14 @@ fn list_with_mixed_atomic_integers_and_objects_with_query_select_all_elements_on
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -23793,10 +24307,10 @@ fn list_with_mixed_atomic_integers_and_objects_with_query_select_all_elements_on
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (15usize, 17usize, 17usize),
-        (23usize, 44usize, 44usize),
-        (50usize, 52usize, 55usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (15usize, 17usize, Some(17usize)),
+        (23usize, 44usize, Some(44usize)),
+        (50usize, 52usize, Some(55usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -23809,12 +24323,14 @@ fn list_with_mixed_atomic_integers_and_objects_with_query_select_all_elements_on
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -23888,14 +24404,14 @@ fn list_with_nested_sublists_to_stress_output_ordering_compressed_with_query_sel
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (1usize, 2usize, 2usize),
-        (3usize, 4usize, 4usize),
-        (5usize, 11usize, 11usize),
-        (6usize, 8usize, 8usize),
-        (9usize, 10usize, 10usize),
-        (12usize, 15usize, 15usize),
-        (13usize, 14usize, 14usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (1usize, 2usize, Some(2usize)),
+        (3usize, 4usize, Some(4usize)),
+        (5usize, 11usize, Some(11usize)),
+        (6usize, 8usize, Some(8usize)),
+        (9usize, 10usize, Some(10usize)),
+        (12usize, 15usize, Some(15usize)),
+        (13usize, 14usize, Some(14usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -23908,12 +24424,14 @@ fn list_with_nested_sublists_to_stress_output_ordering_compressed_with_query_sel
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -23999,14 +24517,14 @@ fn list_with_nested_sublists_to_stress_output_ordering_compressed_with_query_sel
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (1usize, 2usize, 2usize),
-        (3usize, 4usize, 4usize),
-        (5usize, 11usize, 11usize),
-        (6usize, 8usize, 8usize),
-        (9usize, 10usize, 10usize),
-        (12usize, 15usize, 15usize),
-        (13usize, 14usize, 14usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (1usize, 2usize, Some(2usize)),
+        (3usize, 4usize, Some(4usize)),
+        (5usize, 11usize, Some(11usize)),
+        (6usize, 8usize, Some(8usize)),
+        (9usize, 10usize, Some(10usize)),
+        (12usize, 15usize, Some(15usize)),
+        (13usize, 14usize, Some(14usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -24019,12 +24537,14 @@ fn list_with_nested_sublists_to_stress_output_ordering_compressed_with_query_sel
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -24110,14 +24630,14 @@ fn list_with_nested_sublists_to_stress_output_ordering_compressed_with_query_sel
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (1usize, 2usize, 2usize),
-        (3usize, 4usize, 4usize),
-        (5usize, 11usize, 11usize),
-        (6usize, 8usize, 8usize),
-        (9usize, 10usize, 10usize),
-        (12usize, 15usize, 15usize),
-        (13usize, 14usize, 14usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (1usize, 2usize, Some(2usize)),
+        (3usize, 4usize, Some(4usize)),
+        (5usize, 11usize, Some(11usize)),
+        (6usize, 8usize, Some(8usize)),
+        (9usize, 10usize, Some(10usize)),
+        (12usize, 15usize, Some(15usize)),
+        (13usize, 14usize, Some(14usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -24130,12 +24650,14 @@ fn list_with_nested_sublists_to_stress_output_ordering_compressed_with_query_sel
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -24221,14 +24743,14 @@ fn list_with_nested_sublists_to_stress_output_ordering_with_query_select_all_sub
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (4usize, 5usize, 5usize),
-        (9usize, 10usize, 10usize),
-        (14usize, 33usize, 33usize),
-        (20usize, 22usize, 22usize),
-        (28usize, 29usize, 32usize),
-        (37usize, 48usize, 49usize),
-        (43usize, 44usize, 47usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (4usize, 5usize, Some(5usize)),
+        (9usize, 10usize, Some(10usize)),
+        (14usize, 33usize, Some(33usize)),
+        (20usize, 22usize, Some(22usize)),
+        (28usize, 29usize, Some(32usize)),
+        (37usize, 48usize, Some(49usize)),
+        (43usize, 44usize, Some(47usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -24241,12 +24763,14 @@ fn list_with_nested_sublists_to_stress_output_ordering_with_query_select_all_sub
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -24332,14 +24856,14 @@ fn list_with_nested_sublists_to_stress_output_ordering_with_query_select_all_sub
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (4usize, 5usize, 5usize),
-        (9usize, 10usize, 10usize),
-        (14usize, 33usize, 33usize),
-        (20usize, 22usize, 22usize),
-        (28usize, 29usize, 32usize),
-        (37usize, 48usize, 49usize),
-        (43usize, 44usize, 47usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (4usize, 5usize, Some(5usize)),
+        (9usize, 10usize, Some(10usize)),
+        (14usize, 33usize, Some(33usize)),
+        (20usize, 22usize, Some(22usize)),
+        (28usize, 29usize, Some(32usize)),
+        (37usize, 48usize, Some(49usize)),
+        (43usize, 44usize, Some(47usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -24352,12 +24876,14 @@ fn list_with_nested_sublists_to_stress_output_ordering_with_query_select_all_sub
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -24443,14 +24969,14 @@ fn list_with_nested_sublists_to_stress_output_ordering_with_query_select_all_sub
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (4usize, 5usize, 5usize),
-        (9usize, 10usize, 10usize),
-        (14usize, 33usize, 33usize),
-        (20usize, 22usize, 22usize),
-        (28usize, 29usize, 32usize),
-        (37usize, 48usize, 49usize),
-        (43usize, 44usize, 47usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (4usize, 5usize, Some(5usize)),
+        (9usize, 10usize, Some(10usize)),
+        (14usize, 33usize, Some(33usize)),
+        (20usize, 22usize, Some(22usize)),
+        (28usize, 29usize, Some(32usize)),
+        (37usize, 48usize, Some(49usize)),
+        (43usize, 44usize, Some(47usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -24463,12 +24989,14 @@ fn list_with_nested_sublists_to_stress_output_ordering_with_query_select_all_sub
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -24554,7 +25082,7 @@ fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(355usize, 357usize, 357usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(355usize, 357usize, Some(357usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -24566,12 +25094,14 @@ fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -24645,7 +25175,7 @@ fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(355usize, 357usize, 357usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(355usize, 357usize, Some(357usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -24657,12 +25187,14 @@ fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -24736,7 +25268,7 @@ fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(355usize, 357usize, 357usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(355usize, 357usize, Some(357usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -24748,12 +25280,14 @@ fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -24827,7 +25361,10 @@ fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(10usize, 115usize, 115usize), (125usize, 127usize, 127usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (10usize, 115usize, Some(115usize)),
+        (125usize, 127usize, Some(127usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -24839,12 +25376,14 @@ fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -24921,7 +25460,10 @@ fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(10usize, 115usize, 115usize), (125usize, 127usize, 127usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (10usize, 115usize, Some(115usize)),
+        (125usize, 127usize, Some(127usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -24933,12 +25475,14 @@ fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -25015,7 +25559,10 @@ fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(10usize, 115usize, 115usize), (125usize, 127usize, 127usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (10usize, 115usize, Some(115usize)),
+        (125usize, 127usize, Some(127usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -25027,12 +25574,14 @@ fn long_labels_to_search_with_head_skipping_issue_249_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -25109,7 +25658,7 @@ fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(428usize, 430usize, 431usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(428usize, 430usize, Some(431usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -25121,12 +25670,14 @@ fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -25200,7 +25751,7 @@ fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(428usize, 430usize, 431usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(428usize, 430usize, Some(431usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -25212,12 +25763,14 @@ fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -25291,7 +25844,7 @@ fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extr
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(428usize, 430usize, 431usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(428usize, 430usize, Some(431usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -25303,12 +25856,14 @@ fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_extr
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -25382,7 +25937,10 @@ fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_labe
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(14usize, 128usize, 128usize), (194usize, 196usize, 196usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (14usize, 128usize, Some(128usize)),
+        (194usize, 196usize, Some(196usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -25394,12 +25952,14 @@ fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_labe
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -25473,7 +26033,10 @@ fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_labe
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(14usize, 128usize, 128usize), (194usize, 196usize, 196usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (14usize, 128usize, Some(128usize)),
+        (194usize, 196usize, Some(196usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -25485,12 +26048,14 @@ fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_labe
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -25564,7 +26129,10 @@ fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_labe
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(14usize, 128usize, 128usize), (194usize, 196usize, 196usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (14usize, 128usize, Some(128usize)),
+        (194usize, 196usize, Some(196usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -25576,12 +26144,14 @@ fn long_labels_to_search_with_head_skipping_issue_249_with_query_select_the_labe
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -25655,7 +26225,7 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_compressed_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(525usize, 527usize, 527usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(525usize, 527usize, Some(527usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -25667,12 +26237,14 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_compressed_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -25746,7 +26318,7 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_compressed_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(525usize, 527usize, 527usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(525usize, 527usize, Some(527usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -25758,12 +26330,14 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_compressed_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -25837,7 +26411,7 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_compressed_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(525usize, 527usize, 527usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(525usize, 527usize, Some(527usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -25849,12 +26423,14 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_compressed_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -25928,7 +26504,7 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_compressed_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -25940,12 +26516,14 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_compressed_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -26019,7 +26597,7 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_compressed_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -26031,12 +26609,14 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_compressed_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -26110,7 +26690,7 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_compressed_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -26122,12 +26702,14 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_compressed_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -26201,7 +26783,7 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_with_query_select_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(611usize, 613usize, 622usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(611usize, 613usize, Some(622usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -26213,12 +26795,14 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_with_query_select_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -26292,7 +26876,7 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_with_query_select_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(611usize, 613usize, 622usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(611usize, 613usize, Some(622usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -26304,12 +26888,14 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_with_query_select_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -26383,7 +26969,7 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_with_query_select_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(611usize, 613usize, 622usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(611usize, 613usize, Some(622usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -26395,12 +26981,14 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_with_query_select_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -26474,7 +27062,7 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_with_query_select_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -26486,12 +27074,14 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_with_query_select_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -26565,7 +27155,7 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_with_query_select_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -26577,12 +27167,14 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_with_query_select_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -26656,7 +27248,7 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_with_query_select_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -26668,12 +27260,14 @@ fn members_with_escaped_double_quotes_and_braces_and_brackets_with_query_select_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -26747,7 +27341,7 @@ fn nested_atomic_member_compressed_with_query_look_for_b_on_at_least_one_level_o
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(18usize, 20usize, 20usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(18usize, 20usize, Some(20usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -26759,12 +27353,14 @@ fn nested_atomic_member_compressed_with_query_look_for_b_on_at_least_one_level_o
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -26838,7 +27434,7 @@ fn nested_atomic_member_compressed_with_query_look_for_b_on_at_least_one_level_o
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(18usize, 20usize, 20usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(18usize, 20usize, Some(20usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -26850,12 +27446,14 @@ fn nested_atomic_member_compressed_with_query_look_for_b_on_at_least_one_level_o
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -26929,7 +27527,7 @@ fn nested_atomic_member_compressed_with_query_look_for_b_on_at_least_one_level_o
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(18usize, 20usize, 20usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(18usize, 20usize, Some(20usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -26941,12 +27539,14 @@ fn nested_atomic_member_compressed_with_query_look_for_b_on_at_least_one_level_o
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -27020,7 +27620,7 @@ fn nested_atomic_member_compressed_with_query_look_for_descendants_of_an_atomic_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -27032,12 +27632,14 @@ fn nested_atomic_member_compressed_with_query_look_for_descendants_of_an_atomic_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -27111,7 +27713,7 @@ fn nested_atomic_member_compressed_with_query_look_for_descendants_of_an_atomic_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -27123,12 +27725,14 @@ fn nested_atomic_member_compressed_with_query_look_for_descendants_of_an_atomic_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -27202,7 +27806,7 @@ fn nested_atomic_member_compressed_with_query_look_for_descendants_of_an_atomic_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -27214,12 +27818,14 @@ fn nested_atomic_member_compressed_with_query_look_for_descendants_of_an_atomic_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -27293,7 +27899,7 @@ fn nested_atomic_member_compressed_with_query_select_a_number_that_is_a_child_wi
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(5usize, 7usize, 7usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(5usize, 7usize, Some(7usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -27305,12 +27911,14 @@ fn nested_atomic_member_compressed_with_query_select_a_number_that_is_a_child_wi
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -27384,7 +27992,7 @@ fn nested_atomic_member_compressed_with_query_select_a_number_that_is_a_child_wi
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(5usize, 7usize, 7usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(5usize, 7usize, Some(7usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -27396,12 +28004,14 @@ fn nested_atomic_member_compressed_with_query_select_a_number_that_is_a_child_wi
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -27475,7 +28085,7 @@ fn nested_atomic_member_compressed_with_query_select_a_number_that_is_a_child_wi
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(5usize, 7usize, 7usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(5usize, 7usize, Some(7usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -27487,12 +28097,14 @@ fn nested_atomic_member_compressed_with_query_select_a_number_that_is_a_child_wi
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -27566,11 +28178,11 @@ fn nested_atomic_member_compressed_with_query_select_all_decsendants_with_buffer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (5usize, 7usize, 7usize),
-        (12usize, 22usize, 22usize),
-        (13usize, 21usize, 21usize),
-        (18usize, 20usize, 20usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (5usize, 7usize, Some(7usize)),
+        (12usize, 22usize, Some(22usize)),
+        (13usize, 21usize, Some(21usize)),
+        (18usize, 20usize, Some(20usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -27583,12 +28195,14 @@ fn nested_atomic_member_compressed_with_query_select_all_decsendants_with_buffer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -27667,11 +28281,11 @@ fn nested_atomic_member_compressed_with_query_select_all_decsendants_with_mmap_i
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (5usize, 7usize, 7usize),
-        (12usize, 22usize, 22usize),
-        (13usize, 21usize, 21usize),
-        (18usize, 20usize, 20usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (5usize, 7usize, Some(7usize)),
+        (12usize, 22usize, Some(22usize)),
+        (13usize, 21usize, Some(21usize)),
+        (18usize, 20usize, Some(20usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -27684,12 +28298,14 @@ fn nested_atomic_member_compressed_with_query_select_all_decsendants_with_mmap_i
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -27768,11 +28384,11 @@ fn nested_atomic_member_compressed_with_query_select_all_decsendants_with_owned_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (5usize, 7usize, 7usize),
-        (12usize, 22usize, 22usize),
-        (13usize, 21usize, 21usize),
-        (18usize, 20usize, 20usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (5usize, 7usize, Some(7usize)),
+        (12usize, 22usize, Some(22usize)),
+        (13usize, 21usize, Some(21usize)),
+        (18usize, 20usize, Some(20usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -27785,12 +28401,14 @@ fn nested_atomic_member_compressed_with_query_select_all_decsendants_with_owned_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -27869,7 +28487,7 @@ fn nested_atomic_member_compressed_with_query_select_first_item_from_list_descen
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(13usize, 21usize, 21usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(13usize, 21usize, Some(21usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -27881,12 +28499,14 @@ fn nested_atomic_member_compressed_with_query_select_first_item_from_list_descen
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -27960,7 +28580,7 @@ fn nested_atomic_member_compressed_with_query_select_first_item_from_list_descen
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(13usize, 21usize, 21usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(13usize, 21usize, Some(21usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -27972,12 +28592,14 @@ fn nested_atomic_member_compressed_with_query_select_first_item_from_list_descen
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -28051,7 +28673,7 @@ fn nested_atomic_member_compressed_with_query_select_first_item_from_list_descen
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(13usize, 21usize, 21usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(13usize, 21usize, Some(21usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -28063,12 +28685,14 @@ fn nested_atomic_member_compressed_with_query_select_first_item_from_list_descen
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -28142,7 +28766,7 @@ fn nested_atomic_member_compressed_with_query_select_the_first_element_of_b_with
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(13usize, 21usize, 21usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(13usize, 21usize, Some(21usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -28154,12 +28778,14 @@ fn nested_atomic_member_compressed_with_query_select_the_first_element_of_b_with
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -28233,7 +28859,7 @@ fn nested_atomic_member_compressed_with_query_select_the_first_element_of_b_with
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(13usize, 21usize, 21usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(13usize, 21usize, Some(21usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -28245,12 +28871,14 @@ fn nested_atomic_member_compressed_with_query_select_the_first_element_of_b_with
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -28324,7 +28952,7 @@ fn nested_atomic_member_compressed_with_query_select_the_first_element_of_b_with
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(13usize, 21usize, 21usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(13usize, 21usize, Some(21usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -28336,12 +28964,14 @@ fn nested_atomic_member_compressed_with_query_select_the_first_element_of_b_with
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -28415,7 +29045,7 @@ fn nested_atomic_member_compressed_with_query_select_the_nested_b_directly_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(18usize, 20usize, 20usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(18usize, 20usize, Some(20usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -28427,12 +29057,14 @@ fn nested_atomic_member_compressed_with_query_select_the_nested_b_directly_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -28506,7 +29138,7 @@ fn nested_atomic_member_compressed_with_query_select_the_nested_b_directly_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(18usize, 20usize, 20usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(18usize, 20usize, Some(20usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -28518,12 +29150,14 @@ fn nested_atomic_member_compressed_with_query_select_the_nested_b_directly_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -28597,7 +29231,7 @@ fn nested_atomic_member_compressed_with_query_select_the_nested_b_directly_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(18usize, 20usize, 20usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(18usize, 20usize, Some(20usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -28609,12 +29243,14 @@ fn nested_atomic_member_compressed_with_query_select_the_nested_b_directly_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -28688,7 +29324,7 @@ fn nested_atomic_member_compressed_with_query_select_the_second_element_of_b_whi
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -28700,12 +29336,14 @@ fn nested_atomic_member_compressed_with_query_select_the_second_element_of_b_whi
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -28779,7 +29417,7 @@ fn nested_atomic_member_compressed_with_query_select_the_second_element_of_b_whi
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -28791,12 +29429,14 @@ fn nested_atomic_member_compressed_with_query_select_the_second_element_of_b_whi
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -28870,7 +29510,7 @@ fn nested_atomic_member_compressed_with_query_select_the_second_element_of_b_whi
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -28882,12 +29522,14 @@ fn nested_atomic_member_compressed_with_query_select_the_second_element_of_b_whi
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -28961,7 +29603,7 @@ fn nested_atomic_member_compressed_with_query_select_the_second_element_of_the_r
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -28973,12 +29615,14 @@ fn nested_atomic_member_compressed_with_query_select_the_second_element_of_the_r
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -29052,7 +29696,7 @@ fn nested_atomic_member_compressed_with_query_select_the_second_element_of_the_r
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -29064,12 +29708,14 @@ fn nested_atomic_member_compressed_with_query_select_the_second_element_of_the_r
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -29143,7 +29789,7 @@ fn nested_atomic_member_compressed_with_query_select_the_second_element_of_the_r
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -29155,12 +29801,14 @@ fn nested_atomic_member_compressed_with_query_select_the_second_element_of_the_r
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -29234,7 +29882,7 @@ fn nested_atomic_member_with_query_look_for_b_on_at_least_one_level_of_nesting_w
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(53usize, 55usize, 64usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(53usize, 55usize, Some(64usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -29246,12 +29894,14 @@ fn nested_atomic_member_with_query_look_for_b_on_at_least_one_level_of_nesting_w
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -29325,7 +29975,7 @@ fn nested_atomic_member_with_query_look_for_b_on_at_least_one_level_of_nesting_w
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(53usize, 55usize, 64usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(53usize, 55usize, Some(64usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -29337,12 +29987,14 @@ fn nested_atomic_member_with_query_look_for_b_on_at_least_one_level_of_nesting_w
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -29416,7 +30068,7 @@ fn nested_atomic_member_with_query_look_for_b_on_at_least_one_level_of_nesting_w
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(53usize, 55usize, 64usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(53usize, 55usize, Some(64usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -29428,12 +30080,14 @@ fn nested_atomic_member_with_query_look_for_b_on_at_least_one_level_of_nesting_w
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -29507,7 +30161,7 @@ fn nested_atomic_member_with_query_look_for_descendants_of_an_atomic_value_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -29519,12 +30173,14 @@ fn nested_atomic_member_with_query_look_for_descendants_of_an_atomic_value_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -29598,7 +30254,7 @@ fn nested_atomic_member_with_query_look_for_descendants_of_an_atomic_value_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -29610,12 +30266,14 @@ fn nested_atomic_member_with_query_look_for_descendants_of_an_atomic_value_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -29689,7 +30347,7 @@ fn nested_atomic_member_with_query_look_for_descendants_of_an_atomic_value_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -29701,12 +30359,14 @@ fn nested_atomic_member_with_query_look_for_descendants_of_an_atomic_value_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -29780,7 +30440,7 @@ fn nested_atomic_member_with_query_select_a_number_that_is_a_child_with_buffered
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(11usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(11usize, 13usize, Some(13usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -29792,12 +30452,14 @@ fn nested_atomic_member_with_query_select_a_number_that_is_a_child_with_buffered
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -29871,7 +30533,7 @@ fn nested_atomic_member_with_query_select_a_number_that_is_a_child_with_mmap_inp
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(11usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(11usize, 13usize, Some(13usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -29883,12 +30545,14 @@ fn nested_atomic_member_with_query_select_a_number_that_is_a_child_with_mmap_inp
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -29962,7 +30626,7 @@ fn nested_atomic_member_with_query_select_a_number_that_is_a_child_with_owned_by
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(11usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(11usize, 13usize, Some(13usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -29974,12 +30638,14 @@ fn nested_atomic_member_with_query_select_a_number_that_is_a_child_with_owned_by
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -30053,11 +30719,11 @@ fn nested_atomic_member_with_query_select_all_decsendants_with_buffered_input_an
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (11usize, 13usize, 13usize),
-        (24usize, 71usize, 72usize),
-        (34usize, 65usize, 70usize),
-        (53usize, 55usize, 64usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (11usize, 13usize, Some(13usize)),
+        (24usize, 71usize, Some(72usize)),
+        (34usize, 65usize, Some(70usize)),
+        (53usize, 55usize, Some(64usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -30070,12 +30736,14 @@ fn nested_atomic_member_with_query_select_all_decsendants_with_buffered_input_an
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -30159,11 +30827,11 @@ fn nested_atomic_member_with_query_select_all_decsendants_with_mmap_input_and_ap
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (11usize, 13usize, 13usize),
-        (24usize, 71usize, 72usize),
-        (34usize, 65usize, 70usize),
-        (53usize, 55usize, 64usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (11usize, 13usize, Some(13usize)),
+        (24usize, 71usize, Some(72usize)),
+        (34usize, 65usize, Some(70usize)),
+        (53usize, 55usize, Some(64usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -30176,12 +30844,14 @@ fn nested_atomic_member_with_query_select_all_decsendants_with_mmap_input_and_ap
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -30265,11 +30935,11 @@ fn nested_atomic_member_with_query_select_all_decsendants_with_owned_bytes_and_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (11usize, 13usize, 13usize),
-        (24usize, 71usize, 72usize),
-        (34usize, 65usize, 70usize),
-        (53usize, 55usize, 64usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (11usize, 13usize, Some(13usize)),
+        (24usize, 71usize, Some(72usize)),
+        (34usize, 65usize, Some(70usize)),
+        (53usize, 55usize, Some(64usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -30282,12 +30952,14 @@ fn nested_atomic_member_with_query_select_all_decsendants_with_owned_bytes_and_a
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -30371,7 +31043,7 @@ fn nested_atomic_member_with_query_select_first_item_from_list_descendants_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(34usize, 65usize, 70usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(34usize, 65usize, Some(70usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -30383,12 +31055,14 @@ fn nested_atomic_member_with_query_select_first_item_from_list_descendants_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -30462,7 +31136,7 @@ fn nested_atomic_member_with_query_select_first_item_from_list_descendants_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(34usize, 65usize, 70usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(34usize, 65usize, Some(70usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -30474,12 +31148,14 @@ fn nested_atomic_member_with_query_select_first_item_from_list_descendants_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -30553,7 +31229,7 @@ fn nested_atomic_member_with_query_select_first_item_from_list_descendants_with_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(34usize, 65usize, 70usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(34usize, 65usize, Some(70usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -30565,12 +31241,14 @@ fn nested_atomic_member_with_query_select_first_item_from_list_descendants_with_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -30644,7 +31322,7 @@ fn nested_atomic_member_with_query_select_the_first_element_of_b_with_buffered_i
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(34usize, 65usize, 70usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(34usize, 65usize, Some(70usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -30656,12 +31334,14 @@ fn nested_atomic_member_with_query_select_the_first_element_of_b_with_buffered_i
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -30735,7 +31415,7 @@ fn nested_atomic_member_with_query_select_the_first_element_of_b_with_mmap_input
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(34usize, 65usize, 70usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(34usize, 65usize, Some(70usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -30747,12 +31427,14 @@ fn nested_atomic_member_with_query_select_the_first_element_of_b_with_mmap_input
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -30826,7 +31508,7 @@ fn nested_atomic_member_with_query_select_the_first_element_of_b_with_owned_byte
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(34usize, 65usize, 70usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(34usize, 65usize, Some(70usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -30838,12 +31520,14 @@ fn nested_atomic_member_with_query_select_the_first_element_of_b_with_owned_byte
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -30917,7 +31601,7 @@ fn nested_atomic_member_with_query_select_the_nested_b_directly_with_buffered_in
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(53usize, 55usize, 64usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(53usize, 55usize, Some(64usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -30929,12 +31613,14 @@ fn nested_atomic_member_with_query_select_the_nested_b_directly_with_buffered_in
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -31008,7 +31694,7 @@ fn nested_atomic_member_with_query_select_the_nested_b_directly_with_mmap_input_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(53usize, 55usize, 64usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(53usize, 55usize, Some(64usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -31020,12 +31706,14 @@ fn nested_atomic_member_with_query_select_the_nested_b_directly_with_mmap_input_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -31099,7 +31787,7 @@ fn nested_atomic_member_with_query_select_the_nested_b_directly_with_owned_bytes
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(53usize, 55usize, 64usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(53usize, 55usize, Some(64usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -31111,12 +31799,14 @@ fn nested_atomic_member_with_query_select_the_nested_b_directly_with_owned_bytes
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -31190,7 +31880,7 @@ fn nested_atomic_member_with_query_select_the_second_element_of_b_which_does_not
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -31202,12 +31892,14 @@ fn nested_atomic_member_with_query_select_the_second_element_of_b_which_does_not
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -31281,7 +31973,7 @@ fn nested_atomic_member_with_query_select_the_second_element_of_b_which_does_not
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -31293,12 +31985,14 @@ fn nested_atomic_member_with_query_select_the_second_element_of_b_which_does_not
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -31372,7 +32066,7 @@ fn nested_atomic_member_with_query_select_the_second_element_of_b_which_does_not
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -31384,12 +32078,14 @@ fn nested_atomic_member_with_query_select_the_second_element_of_b_which_does_not
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -31463,7 +32159,7 @@ fn nested_atomic_member_with_query_select_the_second_element_of_the_root_which_i
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -31475,12 +32171,14 @@ fn nested_atomic_member_with_query_select_the_second_element_of_the_root_which_i
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -31554,7 +32252,7 @@ fn nested_atomic_member_with_query_select_the_second_element_of_the_root_which_i
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -31566,12 +32264,14 @@ fn nested_atomic_member_with_query_select_the_second_element_of_the_root_which_i
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -31645,7 +32345,7 @@ fn nested_atomic_member_with_query_select_the_second_element_of_the_root_which_i
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -31657,12 +32357,14 @@ fn nested_atomic_member_with_query_select_the_second_element_of_the_root_which_i
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -31736,7 +32438,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(31usize, 33usize, 33usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(31usize, 33usize, Some(33usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -31748,12 +32450,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -31827,7 +32531,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(31usize, 33usize, 33usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(31usize, 33usize, Some(33usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -31839,12 +32543,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -31918,7 +32624,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(31usize, 33usize, 33usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(31usize, 33usize, Some(33usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -31930,12 +32636,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -32009,7 +32717,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(31usize, 33usize, 33usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(31usize, 33usize, Some(33usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -32021,12 +32729,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -32100,7 +32810,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(31usize, 33usize, 33usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(31usize, 33usize, Some(33usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -32112,12 +32822,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -32191,7 +32903,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(31usize, 33usize, 33usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(31usize, 33usize, Some(33usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -32203,12 +32915,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -32282,7 +32996,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(6usize, 35usize, 35usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(6usize, 35usize, Some(35usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -32294,12 +33008,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -32373,7 +33089,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(6usize, 35usize, 35usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(6usize, 35usize, Some(35usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -32385,12 +33101,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -32464,7 +33182,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(6usize, 35usize, 35usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(6usize, 35usize, Some(35usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -32476,12 +33194,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -32555,7 +33275,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -32567,12 +33287,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -32646,7 +33368,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -32658,12 +33380,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -32737,7 +33461,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -32749,12 +33473,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -32828,7 +33554,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(23usize, 25usize, 25usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(23usize, 25usize, Some(25usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -32840,12 +33566,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -32919,7 +33647,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(23usize, 25usize, 25usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(23usize, 25usize, Some(25usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -32931,12 +33659,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -33010,7 +33740,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(23usize, 25usize, 25usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(23usize, 25usize, Some(25usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -33022,12 +33752,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -33101,7 +33833,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(23usize, 25usize, 25usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(23usize, 25usize, Some(25usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -33113,12 +33845,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -33192,7 +33926,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(23usize, 25usize, 25usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(23usize, 25usize, Some(25usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -33204,12 +33938,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -33283,7 +34019,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(23usize, 25usize, 25usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(23usize, 25usize, Some(25usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -33295,12 +34031,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_compresse
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -33374,7 +34112,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(176usize, 178usize, 191usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(176usize, 178usize, Some(191usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -33386,12 +34124,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -33465,7 +34205,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(176usize, 178usize, 191usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(176usize, 178usize, Some(191usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -33477,12 +34217,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -33556,7 +34298,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(176usize, 178usize, 191usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(176usize, 178usize, Some(191usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -33568,12 +34310,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -33647,7 +34391,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(176usize, 178usize, 191usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(176usize, 178usize, Some(191usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -33659,12 +34403,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -33738,7 +34484,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(176usize, 178usize, 191usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(176usize, 178usize, Some(191usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -33750,12 +34496,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -33829,7 +34577,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(176usize, 178usize, 191usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(176usize, 178usize, Some(191usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -33841,12 +34589,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -33920,7 +34670,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(21usize, 202usize, 207usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(21usize, 202usize, Some(207usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -33932,12 +34682,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -34011,7 +34763,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(21usize, 202usize, 207usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(21usize, 202usize, Some(207usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -34023,12 +34775,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -34102,7 +34856,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(21usize, 202usize, 207usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(21usize, 202usize, Some(207usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -34114,12 +34868,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -34193,7 +34949,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -34205,12 +34961,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -34284,7 +35042,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -34296,12 +35054,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -34375,7 +35135,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -34387,12 +35147,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -34466,7 +35228,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(133usize, 135usize, 152usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(133usize, 135usize, Some(152usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -34478,12 +35240,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -34557,7 +35321,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(133usize, 135usize, 152usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(133usize, 135usize, Some(152usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -34569,12 +35333,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -34648,7 +35414,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(133usize, 135usize, 152usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(133usize, 135usize, Some(152usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -34660,12 +35426,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -34739,7 +35507,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(133usize, 135usize, 152usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(133usize, 135usize, Some(152usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -34751,12 +35519,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -34830,7 +35600,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(133usize, 135usize, 152usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(133usize, 135usize, Some(152usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -34842,12 +35612,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -34921,7 +35693,7 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(133usize, 135usize, 152usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(133usize, 135usize, Some(152usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -34933,12 +35705,14 @@ fn object_with_a_list_of_integers_followed_by_an_atomic_integer_member_with_quer
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -35012,7 +35786,7 @@ fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_eq
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -35024,12 +35798,14 @@ fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_eq
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -35103,7 +35879,7 @@ fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_eq
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -35115,12 +35891,14 @@ fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_eq
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -35194,7 +35972,7 @@ fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_eq
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -35206,12 +35984,14 @@ fn object_with_an_empty_key_compressed_with_query_descendant_search_for_a_key_eq
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -35285,7 +36065,7 @@ fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -35297,12 +36077,14 @@ fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -35376,7 +36158,7 @@ fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -35388,12 +36170,14 @@ fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -35467,7 +36251,7 @@ fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -35479,12 +36263,14 @@ fn object_with_an_empty_key_with_query_descendant_search_for_a_key_equal_to_the_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -35558,7 +36344,7 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_compress
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(14usize, 16usize, 16usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(14usize, 16usize, Some(16usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -35570,12 +36356,14 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_compress
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -35649,7 +36437,7 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_compress
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(14usize, 16usize, 16usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(14usize, 16usize, Some(16usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -35661,12 +36449,14 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_compress
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -35740,7 +36530,7 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_compress
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(14usize, 16usize, 16usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(14usize, 16usize, Some(16usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -35752,12 +36542,14 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_compress
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -35831,7 +36623,7 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_compress
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(7usize, 9usize, 9usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(7usize, 9usize, Some(9usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -35843,12 +36635,14 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_compress
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -35922,7 +36716,7 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_compress
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(7usize, 9usize, 9usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(7usize, 9usize, Some(9usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -35934,12 +36728,14 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_compress
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -36013,7 +36809,7 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_compress
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(7usize, 9usize, 9usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(7usize, 9usize, Some(9usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -36025,12 +36821,14 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_compress
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -36104,7 +36902,7 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_with_que
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(26usize, 28usize, 29usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(26usize, 28usize, Some(29usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -36116,12 +36914,14 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_with_que
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -36195,7 +36995,7 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_with_que
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(26usize, 28usize, 29usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(26usize, 28usize, Some(29usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -36207,12 +37007,14 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_with_que
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -36286,7 +37088,7 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_with_que
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(26usize, 28usize, 29usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(26usize, 28usize, Some(29usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -36298,12 +37100,14 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_with_que
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -36377,7 +37181,7 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_with_que
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(13usize, 15usize, 15usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(13usize, 15usize, Some(15usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -36389,12 +37193,14 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_with_que
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -36468,7 +37274,7 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_with_que
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(13usize, 15usize, 15usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(13usize, 15usize, Some(15usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -36480,12 +37286,14 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_with_que
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -36559,7 +37367,7 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_with_que
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(13usize, 15usize, 15usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(13usize, 15usize, Some(15usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -36571,12 +37379,14 @@ fn object_with_two_labels_x_and_x_with_a_preceding_escaped_double_quote_with_que
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -36650,7 +37460,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_direct_pat
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(19usize, 20usize, 20usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(19usize, 20usize, Some(20usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -36662,12 +37472,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_direct_pat
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -36741,7 +37553,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_direct_pat
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(19usize, 20usize, 20usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(19usize, 20usize, Some(20usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -36753,12 +37565,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_direct_pat
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -36832,7 +37646,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_direct_pat
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(19usize, 20usize, 20usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(19usize, 20usize, Some(20usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -36844,12 +37658,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_direct_pat
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -36923,10 +37739,10 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_direct_pat
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (15usize, 21usize, 21usize),
-        (22usize, 28usize, 28usize),
-        (29usize, 35usize, 35usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (15usize, 21usize, Some(21usize)),
+        (22usize, 28usize, Some(28usize)),
+        (29usize, 35usize, Some(35usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -36939,12 +37755,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_direct_pat
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -37018,10 +37836,10 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_direct_pat
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (15usize, 21usize, 21usize),
-        (22usize, 28usize, 28usize),
-        (29usize, 35usize, 35usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (15usize, 21usize, Some(21usize)),
+        (22usize, 28usize, Some(28usize)),
+        (29usize, 35usize, Some(35usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -37034,12 +37852,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_direct_pat
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -37113,10 +37933,10 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_direct_pat
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (15usize, 21usize, 21usize),
-        (22usize, 28usize, 28usize),
-        (29usize, 35usize, 35usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (15usize, 21usize, Some(21usize)),
+        (22usize, 28usize, Some(28usize)),
+        (29usize, 35usize, Some(35usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -37129,12 +37949,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_direct_pat
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -37208,7 +38030,8 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_all
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(2usize, 5usize, 5usize), (11usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(2usize, 5usize, Some(5usize)), (11usize, 13usize, Some(13usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -37220,12 +38043,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_all
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -37299,7 +38124,8 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_all
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(2usize, 5usize, 5usize), (11usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(2usize, 5usize, Some(5usize)), (11usize, 13usize, Some(13usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -37311,12 +38137,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_all
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -37390,7 +38218,8 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_all
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(2usize, 5usize, 5usize), (11usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(2usize, 5usize, Some(5usize)), (11usize, 13usize, Some(13usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -37402,12 +38231,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_all
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -37481,23 +38312,23 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_all
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (1usize, 6usize, 6usize),
-        (2usize, 5usize, 5usize),
-        (3usize, 4usize, 4usize),
-        (7usize, 9usize, 9usize),
-        (10usize, 37usize, 37usize),
-        (11usize, 13usize, 13usize),
-        (14usize, 36usize, 36usize),
-        (15usize, 21usize, 21usize),
-        (16usize, 18usize, 18usize),
-        (19usize, 20usize, 20usize),
-        (22usize, 28usize, 28usize),
-        (23usize, 25usize, 25usize),
-        (26usize, 27usize, 27usize),
-        (29usize, 35usize, 35usize),
-        (30usize, 32usize, 32usize),
-        (33usize, 34usize, 34usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (1usize, 6usize, Some(6usize)),
+        (2usize, 5usize, Some(5usize)),
+        (3usize, 4usize, Some(4usize)),
+        (7usize, 9usize, Some(9usize)),
+        (10usize, 37usize, Some(37usize)),
+        (11usize, 13usize, Some(13usize)),
+        (14usize, 36usize, Some(36usize)),
+        (15usize, 21usize, Some(21usize)),
+        (16usize, 18usize, Some(18usize)),
+        (19usize, 20usize, Some(20usize)),
+        (22usize, 28usize, Some(28usize)),
+        (23usize, 25usize, Some(25usize)),
+        (26usize, 27usize, Some(27usize)),
+        (29usize, 35usize, Some(35usize)),
+        (30usize, 32usize, Some(32usize)),
+        (33usize, 34usize, Some(34usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -37510,12 +38341,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_all
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -37630,23 +38463,23 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_all
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (1usize, 6usize, 6usize),
-        (2usize, 5usize, 5usize),
-        (3usize, 4usize, 4usize),
-        (7usize, 9usize, 9usize),
-        (10usize, 37usize, 37usize),
-        (11usize, 13usize, 13usize),
-        (14usize, 36usize, 36usize),
-        (15usize, 21usize, 21usize),
-        (16usize, 18usize, 18usize),
-        (19usize, 20usize, 20usize),
-        (22usize, 28usize, 28usize),
-        (23usize, 25usize, 25usize),
-        (26usize, 27usize, 27usize),
-        (29usize, 35usize, 35usize),
-        (30usize, 32usize, 32usize),
-        (33usize, 34usize, 34usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (1usize, 6usize, Some(6usize)),
+        (2usize, 5usize, Some(5usize)),
+        (3usize, 4usize, Some(4usize)),
+        (7usize, 9usize, Some(9usize)),
+        (10usize, 37usize, Some(37usize)),
+        (11usize, 13usize, Some(13usize)),
+        (14usize, 36usize, Some(36usize)),
+        (15usize, 21usize, Some(21usize)),
+        (16usize, 18usize, Some(18usize)),
+        (19usize, 20usize, Some(20usize)),
+        (22usize, 28usize, Some(28usize)),
+        (23usize, 25usize, Some(25usize)),
+        (26usize, 27usize, Some(27usize)),
+        (29usize, 35usize, Some(35usize)),
+        (30usize, 32usize, Some(32usize)),
+        (33usize, 34usize, Some(34usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -37659,12 +38492,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_all
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -37779,23 +38614,23 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_all
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (1usize, 6usize, 6usize),
-        (2usize, 5usize, 5usize),
-        (3usize, 4usize, 4usize),
-        (7usize, 9usize, 9usize),
-        (10usize, 37usize, 37usize),
-        (11usize, 13usize, 13usize),
-        (14usize, 36usize, 36usize),
-        (15usize, 21usize, 21usize),
-        (16usize, 18usize, 18usize),
-        (19usize, 20usize, 20usize),
-        (22usize, 28usize, 28usize),
-        (23usize, 25usize, 25usize),
-        (26usize, 27usize, 27usize),
-        (29usize, 35usize, 35usize),
-        (30usize, 32usize, 32usize),
-        (33usize, 34usize, 34usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (1usize, 6usize, Some(6usize)),
+        (2usize, 5usize, Some(5usize)),
+        (3usize, 4usize, Some(4usize)),
+        (7usize, 9usize, Some(9usize)),
+        (10usize, 37usize, Some(37usize)),
+        (11usize, 13usize, Some(13usize)),
+        (14usize, 36usize, Some(36usize)),
+        (15usize, 21usize, Some(21usize)),
+        (16usize, 18usize, Some(18usize)),
+        (19usize, 20usize, Some(20usize)),
+        (22usize, 28usize, Some(28usize)),
+        (23usize, 25usize, Some(25usize)),
+        (26usize, 27usize, Some(27usize)),
+        (29usize, 35usize, Some(35usize)),
+        (30usize, 32usize, Some(32usize)),
+        (33usize, 34usize, Some(34usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -37808,12 +38643,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_all
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -37928,7 +38765,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(2usize, 5usize, 5usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(2usize, 5usize, Some(5usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -37940,12 +38777,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -38019,7 +38858,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(2usize, 5usize, 5usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(2usize, 5usize, Some(5usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -38031,12 +38870,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -38110,7 +38951,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(2usize, 5usize, 5usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(2usize, 5usize, Some(5usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -38122,12 +38963,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -38201,14 +39044,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (2usize, 5usize, 5usize),
-        (3usize, 4usize, 4usize),
-        (11usize, 13usize, 13usize),
-        (15usize, 21usize, 21usize),
-        (16usize, 18usize, 18usize),
-        (23usize, 25usize, 25usize),
-        (30usize, 32usize, 32usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (2usize, 5usize, Some(5usize)),
+        (3usize, 4usize, Some(4usize)),
+        (11usize, 13usize, Some(13usize)),
+        (15usize, 21usize, Some(21usize)),
+        (16usize, 18usize, Some(18usize)),
+        (23usize, 25usize, Some(25usize)),
+        (30usize, 32usize, Some(32usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -38221,12 +39064,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -38312,14 +39157,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (2usize, 5usize, 5usize),
-        (3usize, 4usize, 4usize),
-        (11usize, 13usize, 13usize),
-        (15usize, 21usize, 21usize),
-        (16usize, 18usize, 18usize),
-        (23usize, 25usize, 25usize),
-        (30usize, 32usize, 32usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (2usize, 5usize, Some(5usize)),
+        (3usize, 4usize, Some(4usize)),
+        (11usize, 13usize, Some(13usize)),
+        (15usize, 21usize, Some(21usize)),
+        (16usize, 18usize, Some(18usize)),
+        (23usize, 25usize, Some(25usize)),
+        (30usize, 32usize, Some(32usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -38332,12 +39177,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -38423,14 +39270,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (2usize, 5usize, 5usize),
-        (3usize, 4usize, 4usize),
-        (11usize, 13usize, 13usize),
-        (15usize, 21usize, 21usize),
-        (16usize, 18usize, 18usize),
-        (23usize, 25usize, 25usize),
-        (30usize, 32usize, 32usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (2usize, 5usize, Some(5usize)),
+        (3usize, 4usize, Some(4usize)),
+        (11usize, 13usize, Some(13usize)),
+        (15usize, 21usize, Some(21usize)),
+        (16usize, 18usize, Some(18usize)),
+        (23usize, 25usize, Some(25usize)),
+        (30usize, 32usize, Some(32usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -38443,12 +39290,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -38534,7 +39383,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(11usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(11usize, 13usize, Some(13usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -38546,12 +39395,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -38625,7 +39476,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(11usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(11usize, 13usize, Some(13usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -38637,12 +39488,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -38716,7 +39569,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(11usize, 13usize, 13usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(11usize, 13usize, Some(13usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -38728,12 +39581,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -38807,7 +39662,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(1usize, 6usize, 6usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(1usize, 6usize, Some(6usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -38819,12 +39674,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -38898,7 +39755,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(1usize, 6usize, 6usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(1usize, 6usize, Some(6usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -38910,12 +39767,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -38989,7 +39848,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(1usize, 6usize, 6usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(1usize, 6usize, Some(6usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -39001,12 +39860,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -39080,18 +39941,18 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (11usize, 13usize, 13usize),
-        (14usize, 36usize, 36usize),
-        (15usize, 21usize, 21usize),
-        (16usize, 18usize, 18usize),
-        (19usize, 20usize, 20usize),
-        (22usize, 28usize, 28usize),
-        (23usize, 25usize, 25usize),
-        (26usize, 27usize, 27usize),
-        (29usize, 35usize, 35usize),
-        (30usize, 32usize, 32usize),
-        (33usize, 34usize, 34usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (11usize, 13usize, Some(13usize)),
+        (14usize, 36usize, Some(36usize)),
+        (15usize, 21usize, Some(21usize)),
+        (16usize, 18usize, Some(18usize)),
+        (19usize, 20usize, Some(20usize)),
+        (22usize, 28usize, Some(28usize)),
+        (23usize, 25usize, Some(25usize)),
+        (26usize, 27usize, Some(27usize)),
+        (29usize, 35usize, Some(35usize)),
+        (30usize, 32usize, Some(32usize)),
+        (33usize, 34usize, Some(34usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -39104,12 +39965,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -39211,18 +40074,18 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (11usize, 13usize, 13usize),
-        (14usize, 36usize, 36usize),
-        (15usize, 21usize, 21usize),
-        (16usize, 18usize, 18usize),
-        (19usize, 20usize, 20usize),
-        (22usize, 28usize, 28usize),
-        (23usize, 25usize, 25usize),
-        (26usize, 27usize, 27usize),
-        (29usize, 35usize, 35usize),
-        (30usize, 32usize, 32usize),
-        (33usize, 34usize, 34usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (11usize, 13usize, Some(13usize)),
+        (14usize, 36usize, Some(36usize)),
+        (15usize, 21usize, Some(21usize)),
+        (16usize, 18usize, Some(18usize)),
+        (19usize, 20usize, Some(20usize)),
+        (22usize, 28usize, Some(28usize)),
+        (23usize, 25usize, Some(25usize)),
+        (26usize, 27usize, Some(27usize)),
+        (29usize, 35usize, Some(35usize)),
+        (30usize, 32usize, Some(32usize)),
+        (33usize, 34usize, Some(34usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -39235,12 +40098,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -39342,18 +40207,18 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (11usize, 13usize, 13usize),
-        (14usize, 36usize, 36usize),
-        (15usize, 21usize, 21usize),
-        (16usize, 18usize, 18usize),
-        (19usize, 20usize, 20usize),
-        (22usize, 28usize, 28usize),
-        (23usize, 25usize, 25usize),
-        (26usize, 27usize, 27usize),
-        (29usize, 35usize, 35usize),
-        (30usize, 32usize, 32usize),
-        (33usize, 34usize, 34usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (11usize, 13usize, Some(13usize)),
+        (14usize, 36usize, Some(36usize)),
+        (15usize, 21usize, Some(21usize)),
+        (16usize, 18usize, Some(18usize)),
+        (19usize, 20usize, Some(20usize)),
+        (22usize, 28usize, Some(28usize)),
+        (23usize, 25usize, Some(25usize)),
+        (26usize, 27usize, Some(27usize)),
+        (29usize, 35usize, Some(35usize)),
+        (30usize, 32usize, Some(32usize)),
+        (33usize, 34usize, Some(34usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -39366,12 +40231,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -39473,10 +40340,10 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (19usize, 20usize, 20usize),
-        (26usize, 27usize, 27usize),
-        (33usize, 34usize, 34usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (19usize, 20usize, Some(20usize)),
+        (26usize, 27usize, Some(27usize)),
+        (33usize, 34usize, Some(34usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -39489,12 +40356,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -39568,10 +40437,10 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (19usize, 20usize, 20usize),
-        (26usize, 27usize, 27usize),
-        (33usize, 34usize, 34usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (19usize, 20usize, Some(20usize)),
+        (26usize, 27usize, Some(27usize)),
+        (33usize, 34usize, Some(34usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -39584,12 +40453,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -39663,10 +40534,10 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (19usize, 20usize, 20usize),
-        (26usize, 27usize, 27usize),
-        (33usize, 34usize, 34usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (19usize, 20usize, Some(20usize)),
+        (26usize, 27usize, Some(27usize)),
+        (33usize, 34usize, Some(34usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -39679,12 +40550,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -39758,7 +40631,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(22usize, 28usize, 28usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(22usize, 28usize, Some(28usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -39770,12 +40643,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -39849,7 +40724,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(22usize, 28usize, 28usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(22usize, 28usize, Some(28usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -39861,12 +40736,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -39940,7 +40817,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(22usize, 28usize, 28usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(22usize, 28usize, Some(28usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -39952,12 +40829,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -40031,10 +40910,10 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (19usize, 20usize, 20usize),
-        (26usize, 27usize, 27usize),
-        (33usize, 34usize, 34usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (19usize, 20usize, Some(20usize)),
+        (26usize, 27usize, Some(27usize)),
+        (33usize, 34usize, Some(34usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -40047,12 +40926,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -40126,10 +41007,10 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (19usize, 20usize, 20usize),
-        (26usize, 27usize, 27usize),
-        (33usize, 34usize, 34usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (19usize, 20usize, Some(20usize)),
+        (26usize, 27usize, Some(27usize)),
+        (33usize, 34usize, Some(34usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -40142,12 +41023,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -40221,10 +41104,10 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (19usize, 20usize, 20usize),
-        (26usize, 27usize, 27usize),
-        (33usize, 34usize, 34usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (19usize, 20usize, Some(20usize)),
+        (26usize, 27usize, Some(27usize)),
+        (33usize, 34usize, Some(34usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -40237,12 +41120,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -40316,7 +41201,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(14usize, 36usize, 36usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(14usize, 36usize, Some(36usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -40328,12 +41213,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -40407,7 +41294,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(14usize, 36usize, 36usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(14usize, 36usize, Some(36usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -40419,12 +41306,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -40498,7 +41387,7 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(14usize, 36usize, 36usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(14usize, 36usize, Some(36usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -40510,12 +41399,14 @@ fn only_lists_and_integers_nested_in_each_other_compressed_with_query_select_the
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -40589,7 +41480,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_direct_path_2_1_0_1_w
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(113usize, 114usize, 127usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(113usize, 114usize, Some(127usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -40601,12 +41492,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_direct_path_2_1_0_1_w
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -40680,7 +41573,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_direct_path_2_1_0_1_w
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(113usize, 114usize, 127usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(113usize, 114usize, Some(127usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -40692,12 +41585,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_direct_path_2_1_0_1_w
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -40771,7 +41666,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_direct_path_2_1_0_1_w
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(113usize, 114usize, 127usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(113usize, 114usize, Some(127usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -40783,12 +41678,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_direct_path_2_1_0_1_w
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -40862,10 +41759,10 @@ fn only_lists_and_integers_nested_in_each_other_with_query_direct_path_2_1_and_t
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (75usize, 128usize, 128usize),
-        (142usize, 195usize, 195usize),
-        (209usize, 262usize, 271usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (75usize, 128usize, Some(128usize)),
+        (142usize, 195usize, Some(195usize)),
+        (209usize, 262usize, Some(271usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -40878,12 +41775,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_direct_path_2_1_and_t
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -40961,10 +41860,10 @@ fn only_lists_and_integers_nested_in_each_other_with_query_direct_path_2_1_and_t
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (75usize, 128usize, 128usize),
-        (142usize, 195usize, 195usize),
-        (209usize, 262usize, 271usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (75usize, 128usize, Some(128usize)),
+        (142usize, 195usize, Some(195usize)),
+        (209usize, 262usize, Some(271usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -40977,12 +41876,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_direct_path_2_1_and_t
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -41060,10 +41961,10 @@ fn only_lists_and_integers_nested_in_each_other_with_query_direct_path_2_1_and_t
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (75usize, 128usize, 128usize),
-        (142usize, 195usize, 195usize),
-        (209usize, 262usize, 271usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (75usize, 128usize, Some(128usize)),
+        (142usize, 195usize, Some(195usize)),
+        (209usize, 262usize, Some(271usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -41076,12 +41977,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_direct_path_2_1_and_t
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -41159,7 +42062,8 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_all_nodes_at_d
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(16usize, 19usize, 24usize), (49usize, 51usize, 51usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(16usize, 19usize, Some(24usize)), (49usize, 51usize, Some(51usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -41171,12 +42075,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_all_nodes_at_d
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -41250,7 +42156,8 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_all_nodes_at_d
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(16usize, 19usize, 24usize), (49usize, 51usize, 51usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(16usize, 19usize, Some(24usize)), (49usize, 51usize, Some(51usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -41262,12 +42169,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_all_nodes_at_d
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -41341,7 +42250,8 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_all_nodes_at_d
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(16usize, 19usize, 24usize), (49usize, 51usize, 51usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(16usize, 19usize, Some(24usize)), (49usize, 51usize, Some(51usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -41353,12 +42263,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_all_nodes_at_d
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -41432,23 +42344,23 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_all_non_root_n
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (6usize, 25usize, 25usize),
-        (16usize, 19usize, 24usize),
-        (17usize, 18usize, 18usize),
-        (31usize, 33usize, 33usize),
-        (39usize, 278usize, 279usize),
-        (49usize, 51usize, 51usize),
-        (61usize, 272usize, 277usize),
-        (75usize, 128usize, 128usize),
-        (93usize, 95usize, 95usize),
-        (113usize, 114usize, 127usize),
-        (142usize, 195usize, 195usize),
-        (160usize, 162usize, 162usize),
-        (180usize, 181usize, 194usize),
-        (209usize, 262usize, 271usize),
-        (227usize, 229usize, 229usize),
-        (247usize, 248usize, 261usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (6usize, 25usize, Some(25usize)),
+        (16usize, 19usize, Some(24usize)),
+        (17usize, 18usize, Some(18usize)),
+        (31usize, 33usize, Some(33usize)),
+        (39usize, 278usize, Some(279usize)),
+        (49usize, 51usize, Some(51usize)),
+        (61usize, 272usize, Some(277usize)),
+        (75usize, 128usize, Some(128usize)),
+        (93usize, 95usize, Some(95usize)),
+        (113usize, 114usize, Some(127usize)),
+        (142usize, 195usize, Some(195usize)),
+        (160usize, 162usize, Some(162usize)),
+        (180usize, 181usize, Some(194usize)),
+        (209usize, 262usize, Some(271usize)),
+        (227usize, 229usize, Some(229usize)),
+        (247usize, 248usize, Some(261usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -41461,12 +42373,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_all_non_root_n
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -41564,23 +42478,23 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_all_non_root_n
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (6usize, 25usize, 25usize),
-        (16usize, 19usize, 24usize),
-        (17usize, 18usize, 18usize),
-        (31usize, 33usize, 33usize),
-        (39usize, 278usize, 279usize),
-        (49usize, 51usize, 51usize),
-        (61usize, 272usize, 277usize),
-        (75usize, 128usize, 128usize),
-        (93usize, 95usize, 95usize),
-        (113usize, 114usize, 127usize),
-        (142usize, 195usize, 195usize),
-        (160usize, 162usize, 162usize),
-        (180usize, 181usize, 194usize),
-        (209usize, 262usize, 271usize),
-        (227usize, 229usize, 229usize),
-        (247usize, 248usize, 261usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (6usize, 25usize, Some(25usize)),
+        (16usize, 19usize, Some(24usize)),
+        (17usize, 18usize, Some(18usize)),
+        (31usize, 33usize, Some(33usize)),
+        (39usize, 278usize, Some(279usize)),
+        (49usize, 51usize, Some(51usize)),
+        (61usize, 272usize, Some(277usize)),
+        (75usize, 128usize, Some(128usize)),
+        (93usize, 95usize, Some(95usize)),
+        (113usize, 114usize, Some(127usize)),
+        (142usize, 195usize, Some(195usize)),
+        (160usize, 162usize, Some(162usize)),
+        (180usize, 181usize, Some(194usize)),
+        (209usize, 262usize, Some(271usize)),
+        (227usize, 229usize, Some(229usize)),
+        (247usize, 248usize, Some(261usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -41593,12 +42507,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_all_non_root_n
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -41696,23 +42612,23 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_all_non_root_n
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (6usize, 25usize, 25usize),
-        (16usize, 19usize, 24usize),
-        (17usize, 18usize, 18usize),
-        (31usize, 33usize, 33usize),
-        (39usize, 278usize, 279usize),
-        (49usize, 51usize, 51usize),
-        (61usize, 272usize, 277usize),
-        (75usize, 128usize, 128usize),
-        (93usize, 95usize, 95usize),
-        (113usize, 114usize, 127usize),
-        (142usize, 195usize, 195usize),
-        (160usize, 162usize, 162usize),
-        (180usize, 181usize, 194usize),
-        (209usize, 262usize, 271usize),
-        (227usize, 229usize, 229usize),
-        (247usize, 248usize, 261usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (6usize, 25usize, Some(25usize)),
+        (16usize, 19usize, Some(24usize)),
+        (17usize, 18usize, Some(18usize)),
+        (31usize, 33usize, Some(33usize)),
+        (39usize, 278usize, Some(279usize)),
+        (49usize, 51usize, Some(51usize)),
+        (61usize, 272usize, Some(277usize)),
+        (75usize, 128usize, Some(128usize)),
+        (93usize, 95usize, Some(95usize)),
+        (113usize, 114usize, Some(127usize)),
+        (142usize, 195usize, Some(195usize)),
+        (160usize, 162usize, Some(162usize)),
+        (180usize, 181usize, Some(194usize)),
+        (209usize, 262usize, Some(271usize)),
+        (227usize, 229usize, Some(229usize)),
+        (247usize, 248usize, Some(261usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -41725,12 +42641,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_all_non_root_n
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -41828,7 +42746,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(16usize, 19usize, 24usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(16usize, 19usize, Some(24usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -41840,12 +42758,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -41919,7 +42839,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(16usize, 19usize, 24usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(16usize, 19usize, Some(24usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -41931,12 +42851,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -42010,7 +42932,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(16usize, 19usize, 24usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(16usize, 19usize, Some(24usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -42022,12 +42944,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -42101,14 +43025,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (16usize, 19usize, 24usize),
-        (17usize, 18usize, 18usize),
-        (49usize, 51usize, 51usize),
-        (75usize, 128usize, 128usize),
-        (93usize, 95usize, 95usize),
-        (160usize, 162usize, 162usize),
-        (227usize, 229usize, 229usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (16usize, 19usize, Some(24usize)),
+        (17usize, 18usize, Some(18usize)),
+        (49usize, 51usize, Some(51usize)),
+        (75usize, 128usize, Some(128usize)),
+        (93usize, 95usize, Some(95usize)),
+        (160usize, 162usize, Some(162usize)),
+        (227usize, 229usize, Some(229usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -42121,12 +43045,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -42220,14 +43146,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (16usize, 19usize, 24usize),
-        (17usize, 18usize, 18usize),
-        (49usize, 51usize, 51usize),
-        (75usize, 128usize, 128usize),
-        (93usize, 95usize, 95usize),
-        (160usize, 162usize, 162usize),
-        (227usize, 229usize, 229usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (16usize, 19usize, Some(24usize)),
+        (17usize, 18usize, Some(18usize)),
+        (49usize, 51usize, Some(51usize)),
+        (75usize, 128usize, Some(128usize)),
+        (93usize, 95usize, Some(95usize)),
+        (160usize, 162usize, Some(162usize)),
+        (227usize, 229usize, Some(229usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -42240,12 +43166,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -42339,14 +43267,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (16usize, 19usize, 24usize),
-        (17usize, 18usize, 18usize),
-        (49usize, 51usize, 51usize),
-        (75usize, 128usize, 128usize),
-        (93usize, 95usize, 95usize),
-        (160usize, 162usize, 162usize),
-        (227usize, 229usize, 229usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (16usize, 19usize, Some(24usize)),
+        (17usize, 18usize, Some(18usize)),
+        (49usize, 51usize, Some(51usize)),
+        (75usize, 128usize, Some(128usize)),
+        (93usize, 95usize, Some(95usize)),
+        (160usize, 162usize, Some(162usize)),
+        (227usize, 229usize, Some(229usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -42359,12 +43287,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -42458,7 +43388,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(49usize, 51usize, 51usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(49usize, 51usize, Some(51usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -42470,12 +43400,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -42549,7 +43481,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(49usize, 51usize, 51usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(49usize, 51usize, Some(51usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -42561,12 +43493,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -42640,7 +43574,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(49usize, 51usize, 51usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(49usize, 51usize, Some(51usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -42652,12 +43586,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -42731,7 +43667,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(6usize, 25usize, 25usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(6usize, 25usize, Some(25usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -42743,12 +43679,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -42822,7 +43760,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(6usize, 25usize, 25usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(6usize, 25usize, Some(25usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -42834,12 +43772,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -42913,7 +43853,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(6usize, 25usize, 25usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(6usize, 25usize, Some(25usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -42925,12 +43865,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_first_elem
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -43004,18 +43946,18 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (49usize, 51usize, 51usize),
-        (61usize, 272usize, 277usize),
-        (75usize, 128usize, 128usize),
-        (93usize, 95usize, 95usize),
-        (113usize, 114usize, 127usize),
-        (142usize, 195usize, 195usize),
-        (160usize, 162usize, 162usize),
-        (180usize, 181usize, 194usize),
-        (209usize, 262usize, 271usize),
-        (227usize, 229usize, 229usize),
-        (247usize, 248usize, 261usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (49usize, 51usize, Some(51usize)),
+        (61usize, 272usize, Some(277usize)),
+        (75usize, 128usize, Some(128usize)),
+        (93usize, 95usize, Some(95usize)),
+        (113usize, 114usize, Some(127usize)),
+        (142usize, 195usize, Some(195usize)),
+        (160usize, 162usize, Some(162usize)),
+        (180usize, 181usize, Some(194usize)),
+        (209usize, 262usize, Some(271usize)),
+        (227usize, 229usize, Some(229usize)),
+        (247usize, 248usize, Some(261usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -43028,12 +43970,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -43123,18 +44067,18 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (49usize, 51usize, 51usize),
-        (61usize, 272usize, 277usize),
-        (75usize, 128usize, 128usize),
-        (93usize, 95usize, 95usize),
-        (113usize, 114usize, 127usize),
-        (142usize, 195usize, 195usize),
-        (160usize, 162usize, 162usize),
-        (180usize, 181usize, 194usize),
-        (209usize, 262usize, 271usize),
-        (227usize, 229usize, 229usize),
-        (247usize, 248usize, 261usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (49usize, 51usize, Some(51usize)),
+        (61usize, 272usize, Some(277usize)),
+        (75usize, 128usize, Some(128usize)),
+        (93usize, 95usize, Some(95usize)),
+        (113usize, 114usize, Some(127usize)),
+        (142usize, 195usize, Some(195usize)),
+        (160usize, 162usize, Some(162usize)),
+        (180usize, 181usize, Some(194usize)),
+        (209usize, 262usize, Some(271usize)),
+        (227usize, 229usize, Some(229usize)),
+        (247usize, 248usize, Some(261usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -43147,12 +44091,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -43242,18 +44188,18 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (49usize, 51usize, 51usize),
-        (61usize, 272usize, 277usize),
-        (75usize, 128usize, 128usize),
-        (93usize, 95usize, 95usize),
-        (113usize, 114usize, 127usize),
-        (142usize, 195usize, 195usize),
-        (160usize, 162usize, 162usize),
-        (180usize, 181usize, 194usize),
-        (209usize, 262usize, 271usize),
-        (227usize, 229usize, 229usize),
-        (247usize, 248usize, 261usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (49usize, 51usize, Some(51usize)),
+        (61usize, 272usize, Some(277usize)),
+        (75usize, 128usize, Some(128usize)),
+        (93usize, 95usize, Some(95usize)),
+        (113usize, 114usize, Some(127usize)),
+        (142usize, 195usize, Some(195usize)),
+        (160usize, 162usize, Some(162usize)),
+        (180usize, 181usize, Some(194usize)),
+        (209usize, 262usize, Some(271usize)),
+        (227usize, 229usize, Some(229usize)),
+        (247usize, 248usize, Some(261usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -43266,12 +44212,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -43361,10 +44309,10 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (113usize, 114usize, 127usize),
-        (180usize, 181usize, 194usize),
-        (247usize, 248usize, 261usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (113usize, 114usize, Some(127usize)),
+        (180usize, 181usize, Some(194usize)),
+        (247usize, 248usize, Some(261usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -43377,12 +44325,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -43456,10 +44406,10 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (113usize, 114usize, 127usize),
-        (180usize, 181usize, 194usize),
-        (247usize, 248usize, 261usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (113usize, 114usize, Some(127usize)),
+        (180usize, 181usize, Some(194usize)),
+        (247usize, 248usize, Some(261usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -43472,12 +44422,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -43551,10 +44503,10 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (113usize, 114usize, 127usize),
-        (180usize, 181usize, 194usize),
-        (247usize, 248usize, 261usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (113usize, 114usize, Some(127usize)),
+        (180usize, 181usize, Some(194usize)),
+        (247usize, 248usize, Some(261usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -43567,12 +44519,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -43646,7 +44600,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(142usize, 195usize, 195usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(142usize, 195usize, Some(195usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -43658,12 +44612,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -43737,7 +44693,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(142usize, 195usize, 195usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(142usize, 195usize, Some(195usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -43749,12 +44705,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -43828,7 +44786,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(142usize, 195usize, 195usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(142usize, 195usize, Some(195usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -43840,12 +44798,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_long_list_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -43919,10 +44879,10 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_path_2_1_t
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (113usize, 114usize, 127usize),
-        (180usize, 181usize, 194usize),
-        (247usize, 248usize, 261usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (113usize, 114usize, Some(127usize)),
+        (180usize, 181usize, Some(194usize)),
+        (247usize, 248usize, Some(261usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -43935,12 +44895,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_path_2_1_t
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -44014,10 +44976,10 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_path_2_1_t
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (113usize, 114usize, 127usize),
-        (180usize, 181usize, 194usize),
-        (247usize, 248usize, 261usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (113usize, 114usize, Some(127usize)),
+        (180usize, 181usize, Some(194usize)),
+        (247usize, 248usize, Some(261usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -44030,12 +44992,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_path_2_1_t
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -44109,10 +45073,10 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_path_2_1_t
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (113usize, 114usize, 127usize),
-        (180usize, 181usize, 194usize),
-        (247usize, 248usize, 261usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (113usize, 114usize, Some(127usize)),
+        (180usize, 181usize, Some(194usize)),
+        (247usize, 248usize, Some(261usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -44125,12 +45089,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_path_2_1_t
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -44204,7 +45170,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_second_ele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(61usize, 272usize, 277usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(61usize, 272usize, Some(277usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -44216,12 +45182,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_second_ele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -44295,7 +45263,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_second_ele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(61usize, 272usize, 277usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(61usize, 272usize, Some(277usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -44307,12 +45275,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_second_ele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -44386,7 +45356,7 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_second_ele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(61usize, 272usize, 277usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(61usize, 272usize, Some(277usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -44398,12 +45368,14 @@ fn only_lists_and_integers_nested_in_each_other_with_query_select_the_second_ele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -44477,7 +45449,8 @@ fn short_description_of_the_inline_input_structure_compressed_with_query_select_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(8usize, 16usize, 16usize), (25usize, 27usize, 27usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(8usize, 16usize, Some(16usize)), (25usize, 27usize, Some(27usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -44489,12 +45462,14 @@ fn short_description_of_the_inline_input_structure_compressed_with_query_select_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -44568,7 +45543,8 @@ fn short_description_of_the_inline_input_structure_compressed_with_query_select_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(8usize, 16usize, 16usize), (25usize, 27usize, 27usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(8usize, 16usize, Some(16usize)), (25usize, 27usize, Some(27usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -44580,12 +45556,14 @@ fn short_description_of_the_inline_input_structure_compressed_with_query_select_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -44659,7 +45637,8 @@ fn short_description_of_the_inline_input_structure_compressed_with_query_select_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(8usize, 16usize, 16usize), (25usize, 27usize, 27usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(8usize, 16usize, Some(16usize)), (25usize, 27usize, Some(27usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -44671,12 +45650,14 @@ fn short_description_of_the_inline_input_structure_compressed_with_query_select_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -44750,7 +45731,8 @@ fn short_description_of_the_inline_input_structure_with_query_select_all_subdocu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(12usize, 20usize, 20usize), (33usize, 35usize, 36usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(12usize, 20usize, Some(20usize)), (33usize, 35usize, Some(36usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -44762,12 +45744,14 @@ fn short_description_of_the_inline_input_structure_with_query_select_all_subdocu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -44841,7 +45825,8 @@ fn short_description_of_the_inline_input_structure_with_query_select_all_subdocu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(12usize, 20usize, 20usize), (33usize, 35usize, 36usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(12usize, 20usize, Some(20usize)), (33usize, 35usize, Some(36usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -44853,12 +45838,14 @@ fn short_description_of_the_inline_input_structure_with_query_select_all_subdocu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -44932,7 +45919,8 @@ fn short_description_of_the_inline_input_structure_with_query_select_all_subdocu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(12usize, 20usize, 20usize), (33usize, 35usize, 36usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(12usize, 20usize, Some(20usize)), (33usize, 35usize, Some(36usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -44944,12 +45932,14 @@ fn short_description_of_the_inline_input_structure_with_query_select_all_subdocu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -45096,7 +46086,10 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(169usize, 185usize, 185usize), (211usize, 227usize, 227usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (169usize, 185usize, Some(185usize)),
+        (211usize, 227usize, Some(227usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -45108,12 +46101,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -45187,7 +46182,10 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(169usize, 185usize, 185usize), (211usize, 227usize, 227usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (169usize, 185usize, Some(185usize)),
+        (211usize, 227usize, Some(227usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -45199,12 +46197,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -45278,7 +46278,10 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(169usize, 185usize, 185usize), (211usize, 227usize, 227usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (169usize, 185usize, Some(185usize)),
+        (211usize, 227usize, Some(227usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -45290,12 +46293,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -45369,7 +46374,7 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(151usize, 159usize, 159usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(151usize, 159usize, Some(159usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -45381,12 +46386,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -45460,7 +46467,7 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(151usize, 159usize, 159usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(151usize, 159usize, Some(159usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -45472,12 +46479,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -45551,7 +46560,7 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(151usize, 159usize, 159usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(151usize, 159usize, Some(159usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -45563,12 +46572,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -45642,7 +46653,7 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(143usize, 186usize, 186usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(143usize, 186usize, Some(186usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -45654,12 +46665,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -45733,7 +46746,7 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(143usize, 186usize, 186usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(143usize, 186usize, Some(186usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -45745,12 +46758,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -45824,7 +46839,7 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(143usize, 186usize, 186usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(143usize, 186usize, Some(186usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -45836,12 +46851,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_compres
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -45915,7 +46932,10 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(271usize, 287usize, 296usize), (359usize, 375usize, 384usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (271usize, 287usize, Some(296usize)),
+        (359usize, 375usize, Some(384usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -45927,12 +46947,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -46006,7 +47028,10 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(271usize, 287usize, 296usize), (359usize, 375usize, 384usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (271usize, 287usize, Some(296usize)),
+        (359usize, 375usize, Some(384usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -46018,12 +47043,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -46097,7 +47124,10 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(271usize, 287usize, 296usize), (359usize, 375usize, 384usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (271usize, 287usize, Some(296usize)),
+        (359usize, 375usize, Some(384usize)),
+    ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -46109,12 +47139,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -46188,7 +47220,7 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(239usize, 247usize, 247usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(239usize, 247usize, Some(247usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -46200,12 +47232,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -46279,7 +47313,7 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(239usize, 247usize, 247usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(239usize, 247usize, Some(247usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -46291,12 +47325,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -46370,7 +47406,7 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(239usize, 247usize, 247usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(239usize, 247usize, Some(247usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -46382,12 +47418,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -46461,7 +47499,7 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(217usize, 297usize, 297usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(217usize, 297usize, Some(297usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -46473,12 +47511,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -46553,7 +47593,7 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(217usize, 297usize, 297usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(217usize, 297usize, Some(297usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -46565,12 +47605,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -46645,7 +47687,7 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(217usize, 297usize, 297usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(217usize, 297usize, Some(297usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -46657,12 +47699,14 @@ fn short_json_with_objects_and_lists_given_as_an_example_on_jsonpath_com_with_qu
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -46737,7 +47781,8 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(6usize, 8usize, 8usize), (15usize, 17usize, 17usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(6usize, 8usize, Some(8usize)), (15usize, 17usize, Some(17usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -46749,12 +47794,14 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -46828,7 +47875,8 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(6usize, 8usize, 8usize), (15usize, 17usize, 17usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(6usize, 8usize, Some(8usize)), (15usize, 17usize, Some(17usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -46840,12 +47888,14 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -46919,7 +47969,8 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(6usize, 8usize, 8usize), (15usize, 17usize, 17usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(6usize, 8usize, Some(8usize)), (15usize, 17usize, Some(17usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -46931,12 +47982,14 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -47010,11 +48063,11 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (5usize, 9usize, 9usize),
-        (14usize, 18usize, 18usize),
-        (23usize, 25usize, 25usize),
-        (30usize, 32usize, 32usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (5usize, 9usize, Some(9usize)),
+        (14usize, 18usize, Some(18usize)),
+        (23usize, 25usize, Some(25usize)),
+        (30usize, 32usize, Some(32usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -47027,12 +48080,14 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -47111,11 +48166,11 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (5usize, 9usize, 9usize),
-        (14usize, 18usize, 18usize),
-        (23usize, 25usize, 25usize),
-        (30usize, 32usize, 32usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (5usize, 9usize, Some(9usize)),
+        (14usize, 18usize, Some(18usize)),
+        (23usize, 25usize, Some(25usize)),
+        (30usize, 32usize, Some(32usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -47128,12 +48183,14 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -47212,11 +48269,11 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (5usize, 9usize, 9usize),
-        (14usize, 18usize, 18usize),
-        (23usize, 25usize, 25usize),
-        (30usize, 32usize, 32usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (5usize, 9usize, Some(9usize)),
+        (14usize, 18usize, Some(18usize)),
+        (23usize, 25usize, Some(25usize)),
+        (30usize, 32usize, Some(32usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -47229,12 +48286,14 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -47313,7 +48372,8 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(6usize, 8usize, 8usize), (15usize, 17usize, 17usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(6usize, 8usize, Some(8usize)), (15usize, 17usize, Some(17usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -47325,12 +48385,14 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -47404,7 +48466,8 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(6usize, 8usize, 8usize), (15usize, 17usize, 17usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(6usize, 8usize, Some(8usize)), (15usize, 17usize, Some(17usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -47416,12 +48479,14 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -47495,7 +48560,8 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(6usize, 8usize, 8usize), (15usize, 17usize, 17usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(6usize, 8usize, Some(8usize)), (15usize, 17usize, Some(17usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -47507,12 +48573,14 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -47586,13 +48654,13 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (5usize, 9usize, 9usize),
-        (6usize, 8usize, 8usize),
-        (14usize, 18usize, 18usize),
-        (15usize, 17usize, 17usize),
-        (23usize, 25usize, 25usize),
-        (30usize, 32usize, 32usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (5usize, 9usize, Some(9usize)),
+        (6usize, 8usize, Some(8usize)),
+        (14usize, 18usize, Some(18usize)),
+        (15usize, 17usize, Some(17usize)),
+        (23usize, 25usize, Some(25usize)),
+        (30usize, 32usize, Some(32usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -47605,12 +48673,14 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -47695,13 +48765,13 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (5usize, 9usize, 9usize),
-        (6usize, 8usize, 8usize),
-        (14usize, 18usize, 18usize),
-        (15usize, 17usize, 17usize),
-        (23usize, 25usize, 25usize),
-        (30usize, 32usize, 32usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (5usize, 9usize, Some(9usize)),
+        (6usize, 8usize, Some(8usize)),
+        (14usize, 18usize, Some(18usize)),
+        (15usize, 17usize, Some(17usize)),
+        (23usize, 25usize, Some(25usize)),
+        (30usize, 32usize, Some(32usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -47714,12 +48784,14 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -47804,13 +48876,13 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (5usize, 9usize, 9usize),
-        (6usize, 8usize, 8usize),
-        (14usize, 18usize, 18usize),
-        (15usize, 17usize, 17usize),
-        (23usize, 25usize, 25usize),
-        (30usize, 32usize, 32usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (5usize, 9usize, Some(9usize)),
+        (6usize, 8usize, Some(8usize)),
+        (14usize, 18usize, Some(18usize)),
+        (15usize, 17usize, Some(17usize)),
+        (23usize, 25usize, Some(25usize)),
+        (30usize, 32usize, Some(32usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -47823,12 +48895,14 @@ fn single_element_lists_empty_lists_and_empty_objects_compressed_with_query_sele
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -47913,7 +48987,8 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(21usize, 23usize, 28usize), (50usize, 52usize, 57usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(21usize, 23usize, Some(28usize)), (50usize, 52usize, Some(57usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -47925,12 +49000,14 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -48004,7 +49081,8 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(21usize, 23usize, 28usize), (50usize, 52usize, 57usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(21usize, 23usize, Some(28usize)), (50usize, 52usize, Some(57usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -48016,12 +49094,14 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -48095,7 +49175,8 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(21usize, 23usize, 28usize), (50usize, 52usize, 57usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(21usize, 23usize, Some(28usize)), (50usize, 52usize, Some(57usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -48107,12 +49188,14 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -48186,11 +49269,11 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (11usize, 29usize, 29usize),
-        (40usize, 58usize, 58usize),
-        (69usize, 71usize, 71usize),
-        (82usize, 84usize, 85usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (11usize, 29usize, Some(29usize)),
+        (40usize, 58usize, Some(58usize)),
+        (69usize, 71usize, Some(71usize)),
+        (82usize, 84usize, Some(85usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -48203,12 +49286,14 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -48287,11 +49372,11 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (11usize, 29usize, 29usize),
-        (40usize, 58usize, 58usize),
-        (69usize, 71usize, 71usize),
-        (82usize, 84usize, 85usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (11usize, 29usize, Some(29usize)),
+        (40usize, 58usize, Some(58usize)),
+        (69usize, 71usize, Some(71usize)),
+        (82usize, 84usize, Some(85usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -48304,12 +49389,14 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -48388,11 +49475,11 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (11usize, 29usize, 29usize),
-        (40usize, 58usize, 58usize),
-        (69usize, 71usize, 71usize),
-        (82usize, 84usize, 85usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (11usize, 29usize, Some(29usize)),
+        (40usize, 58usize, Some(58usize)),
+        (69usize, 71usize, Some(71usize)),
+        (82usize, 84usize, Some(85usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -48405,12 +49492,14 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -48489,7 +49578,8 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(21usize, 23usize, 28usize), (50usize, 52usize, 57usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(21usize, 23usize, Some(28usize)), (50usize, 52usize, Some(57usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -48501,12 +49591,14 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -48580,7 +49672,8 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(21usize, 23usize, 28usize), (50usize, 52usize, 57usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(21usize, 23usize, Some(28usize)), (50usize, 52usize, Some(57usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -48592,12 +49685,14 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -48671,7 +49766,8 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(21usize, 23usize, 28usize), (50usize, 52usize, 57usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> =
+        vec![(21usize, 23usize, Some(28usize)), (50usize, 52usize, Some(57usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -48683,12 +49779,14 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -48762,13 +49860,13 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (11usize, 29usize, 29usize),
-        (21usize, 23usize, 28usize),
-        (40usize, 58usize, 58usize),
-        (50usize, 52usize, 57usize),
-        (69usize, 71usize, 71usize),
-        (82usize, 84usize, 85usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (11usize, 29usize, Some(29usize)),
+        (21usize, 23usize, Some(28usize)),
+        (40usize, 58usize, Some(58usize)),
+        (50usize, 52usize, Some(57usize)),
+        (69usize, 71usize, Some(71usize)),
+        (82usize, 84usize, Some(85usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -48781,12 +49879,14 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -48871,13 +49971,13 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (11usize, 29usize, 29usize),
-        (21usize, 23usize, 28usize),
-        (40usize, 58usize, 58usize),
-        (50usize, 52usize, 57usize),
-        (69usize, 71usize, 71usize),
-        (82usize, 84usize, 85usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (11usize, 29usize, Some(29usize)),
+        (21usize, 23usize, Some(28usize)),
+        (40usize, 58usize, Some(58usize)),
+        (50usize, 52usize, Some(57usize)),
+        (69usize, 71usize, Some(71usize)),
+        (82usize, 84usize, Some(85usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -48890,12 +49990,14 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -48980,13 +50082,13 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (11usize, 29usize, 29usize),
-        (21usize, 23usize, 28usize),
-        (40usize, 58usize, 58usize),
-        (50usize, 52usize, 57usize),
-        (69usize, 71usize, 71usize),
-        (82usize, 84usize, 85usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (11usize, 29usize, Some(29usize)),
+        (21usize, 23usize, Some(28usize)),
+        (40usize, 58usize, Some(58usize)),
+        (50usize, 52usize, Some(57usize)),
+        (69usize, 71usize, Some(71usize)),
+        (82usize, 84usize, Some(85usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -48999,12 +50101,14 @@ fn single_element_lists_empty_lists_and_empty_objects_with_query_select_all_node
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -49090,11 +50194,11 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_compre
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (178usize, 194usize, 194usize),
-        (220usize, 236usize, 236usize),
-        (426usize, 442usize, 442usize),
-        (468usize, 484usize, 484usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (178usize, 194usize, Some(194usize)),
+        (220usize, 236usize, Some(236usize)),
+        (426usize, 442usize, Some(442usize)),
+        (468usize, 484usize, Some(484usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -49107,12 +50211,14 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_compre
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -49205,11 +50311,11 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_compre
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (178usize, 194usize, 194usize),
-        (220usize, 236usize, 236usize),
-        (426usize, 442usize, 442usize),
-        (468usize, 484usize, 484usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (178usize, 194usize, Some(194usize)),
+        (220usize, 236usize, Some(236usize)),
+        (426usize, 442usize, Some(442usize)),
+        (468usize, 484usize, Some(484usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -49222,12 +50328,14 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_compre
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -49320,11 +50428,11 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_compre
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (178usize, 194usize, 194usize),
-        (220usize, 236usize, 236usize),
-        (426usize, 442usize, 442usize),
-        (468usize, 484usize, 484usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (178usize, 194usize, Some(194usize)),
+        (220usize, 236usize, Some(236usize)),
+        (426usize, 442usize, Some(442usize)),
+        (468usize, 484usize, Some(484usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -49337,12 +50445,14 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_compre
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -49435,11 +50545,11 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_compre
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (160usize, 168usize, 168usize),
-        (204usize, 210usize, 210usize),
-        (408usize, 416usize, 416usize),
-        (452usize, 458usize, 458usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (160usize, 168usize, Some(168usize)),
+        (204usize, 210usize, Some(210usize)),
+        (408usize, 416usize, Some(416usize)),
+        (452usize, 458usize, Some(458usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -49452,12 +50562,14 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_compre
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -49545,11 +50657,11 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_compre
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (160usize, 168usize, 168usize),
-        (204usize, 210usize, 210usize),
-        (408usize, 416usize, 416usize),
-        (452usize, 458usize, 458usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (160usize, 168usize, Some(168usize)),
+        (204usize, 210usize, Some(210usize)),
+        (408usize, 416usize, Some(416usize)),
+        (452usize, 458usize, Some(458usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -49562,12 +50674,14 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_compre
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -49655,11 +50769,11 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_compre
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (160usize, 168usize, 168usize),
-        (204usize, 210usize, 210usize),
-        (408usize, 416usize, 416usize),
-        (452usize, 458usize, 458usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (160usize, 168usize, Some(168usize)),
+        (204usize, 210usize, Some(210usize)),
+        (408usize, 416usize, Some(416usize)),
+        (452usize, 458usize, Some(458usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -49672,12 +50786,14 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_compre
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -49764,11 +50880,11 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_with_q
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (334usize, 350usize, 363usize),
-        (438usize, 454usize, 467usize),
-        (936usize, 952usize, 973usize),
-        (1072usize, 1088usize, 1109usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (334usize, 350usize, Some(363usize)),
+        (438usize, 454usize, Some(467usize)),
+        (936usize, 952usize, Some(973usize)),
+        (1072usize, 1088usize, Some(1109usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -49781,12 +50897,14 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_with_q
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -49874,11 +50992,11 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_with_q
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (334usize, 350usize, 363usize),
-        (438usize, 454usize, 467usize),
-        (936usize, 952usize, 973usize),
-        (1072usize, 1088usize, 1109usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (334usize, 350usize, Some(363usize)),
+        (438usize, 454usize, Some(467usize)),
+        (936usize, 952usize, Some(973usize)),
+        (1072usize, 1088usize, Some(1109usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -49891,12 +51009,14 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_with_q
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -49984,11 +51104,11 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_with_q
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (334usize, 350usize, 363usize),
-        (438usize, 454usize, 467usize),
-        (936usize, 952usize, 973usize),
-        (1072usize, 1088usize, 1109usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (334usize, 350usize, Some(363usize)),
+        (438usize, 454usize, Some(467usize)),
+        (936usize, 952usize, Some(973usize)),
+        (1072usize, 1088usize, Some(1109usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -50001,12 +51121,14 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_with_q
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -50094,11 +51216,11 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_with_q
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (298usize, 306usize, 306usize),
-        (404usize, 410usize, 410usize),
-        (892usize, 900usize, 900usize),
-        (1030usize, 1036usize, 1036usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (298usize, 306usize, Some(306usize)),
+        (404usize, 410usize, Some(410usize)),
+        (892usize, 900usize, Some(900usize)),
+        (1030usize, 1036usize, Some(1036usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -50111,12 +51233,14 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_with_q
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -50199,11 +51323,11 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_with_q
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (298usize, 306usize, 306usize),
-        (404usize, 410usize, 410usize),
-        (892usize, 900usize, 900usize),
-        (1030usize, 1036usize, 1036usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (298usize, 306usize, Some(306usize)),
+        (404usize, 410usize, Some(410usize)),
+        (892usize, 900usize, Some(900usize)),
+        (1030usize, 1036usize, Some(1036usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -50216,12 +51340,14 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_with_q
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -50304,11 +51430,11 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_with_q
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (298usize, 306usize, 306usize),
-        (404usize, 410usize, 410usize),
-        (892usize, 900usize, 900usize),
-        (1030usize, 1036usize, 1036usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (298usize, 306usize, Some(306usize)),
+        (404usize, 410usize, Some(410usize)),
+        (892usize, 900usize, Some(900usize)),
+        (1030usize, 1036usize, Some(1036usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -50321,12 +51447,14 @@ fn the_example_on_jsonpath_com_extended_with_another_nested_person_object_with_q
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -50409,7 +51537,7 @@ fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -50421,12 +51549,14 @@ fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -50500,7 +51630,7 @@ fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -50512,12 +51642,14 @@ fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -50592,7 +51724,7 @@ fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -50604,12 +51736,14 @@ fn the_root_is_a_non_empty_string_with_query_look_for_the_key_equal_to_the_root_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -50687,7 +51821,7 @@ fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_th
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -50699,12 +51833,14 @@ fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_th
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -50778,7 +51914,7 @@ fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_th
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -50790,12 +51926,14 @@ fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_th
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -50870,7 +52008,7 @@ fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_th
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -50882,12 +52020,14 @@ fn the_root_is_a_non_empty_string_with_query_select_all_subdocuments_of_which_th
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -50965,7 +52105,7 @@ fn the_root_is_a_non_empty_string_with_query_select_the_root_with_buffered_input
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 13usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -50977,12 +52117,14 @@ fn the_root_is_a_non_empty_string_with_query_select_the_root_with_buffered_input
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -51056,7 +52198,7 @@ fn the_root_is_a_non_empty_string_with_query_select_the_root_with_mmap_input_and
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 13usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51068,12 +52210,14 @@ fn the_root_is_a_non_empty_string_with_query_select_the_root_with_mmap_input_and
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -51148,7 +52292,7 @@ fn the_root_is_a_non_empty_string_with_query_select_the_root_with_owned_bytes_an
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 13usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51160,12 +52304,14 @@ fn the_root_is_a_non_empty_string_with_query_select_the_root_with_owned_bytes_an
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -51244,7 +52390,7 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51256,12 +52402,14 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -51340,7 +52488,7 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51352,12 +52500,14 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -51437,7 +52587,7 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51449,12 +52599,14 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -51537,7 +52689,7 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 18usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 18usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51549,12 +52701,14 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -51633,7 +52787,7 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 18usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 18usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51645,12 +52799,14 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -51730,7 +52886,7 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 18usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 18usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51742,12 +52898,14 @@ fn the_root_is_an_atomic_floating_point_number_in_scientific_notation_with_query
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -51829,7 +52987,7 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocument
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51841,12 +52999,14 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocument
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -51920,7 +53080,7 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocument
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -51932,12 +53092,14 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocument
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -52011,7 +53173,7 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocument
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52023,12 +53185,14 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_all_subdocument
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -52102,7 +53266,7 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_b
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 14usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 14usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52114,12 +53278,14 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_b
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -52193,7 +53359,7 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_m
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 14usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 14usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52205,12 +53371,14 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_m
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -52284,7 +53452,7 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_o
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 14usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 14usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52296,12 +53464,14 @@ fn the_root_is_an_atomic_floating_point_number_with_query_select_the_root_with_o
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -52375,7 +53545,7 @@ fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_w
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52387,12 +53557,14 @@ fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_w
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -52466,7 +53638,7 @@ fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_w
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52478,12 +53650,14 @@ fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_w
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -52558,7 +53732,7 @@ fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_w
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52570,12 +53744,14 @@ fn the_root_is_an_atomic_integral_number_with_query_select_all_subdocuments_of_w
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -52653,7 +53829,7 @@ fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_buffere
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 9usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 9usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52665,12 +53841,14 @@ fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_buffere
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -52744,7 +53922,7 @@ fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_mmap_in
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 9usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 9usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52756,12 +53934,14 @@ fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_mmap_in
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -52836,7 +54016,7 @@ fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_owned_b
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 9usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 9usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52848,12 +54028,14 @@ fn the_root_is_an_atomic_integral_number_with_query_select_the_root_with_owned_b
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -52931,7 +54113,7 @@ fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -52943,12 +54125,14 @@ fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -53022,7 +54206,7 @@ fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53034,12 +54218,14 @@ fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -53113,7 +54299,7 @@ fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53125,12 +54311,14 @@ fn the_root_is_an_empty_string_with_query_look_for_an_empty_key_which_should_not
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -53204,7 +54392,7 @@ fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53216,12 +54404,14 @@ fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -53295,7 +54485,7 @@ fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53307,12 +54497,14 @@ fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -53386,7 +54578,7 @@ fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53398,12 +54590,14 @@ fn the_root_is_an_empty_string_with_query_select_all_subdocuments_of_which_there
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -53477,7 +54671,7 @@ fn the_root_is_an_empty_string_with_query_select_the_root_with_buffered_input_an
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53489,12 +54683,14 @@ fn the_root_is_an_empty_string_with_query_select_the_root_with_buffered_input_an
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -53568,7 +54764,7 @@ fn the_root_is_an_empty_string_with_query_select_the_root_with_mmap_input_and_ap
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53580,12 +54776,14 @@ fn the_root_is_an_empty_string_with_query_select_the_root_with_mmap_input_and_ap
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -53659,7 +54857,7 @@ fn the_root_is_an_empty_string_with_query_select_the_root_with_owned_bytes_and_a
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 2usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 2usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53671,12 +54869,14 @@ fn the_root_is_an_empty_string_with_query_select_the_root_with_owned_bytes_and_a
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -53750,7 +54950,7 @@ fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_whic
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53762,12 +54962,14 @@ fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_whic
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -53841,7 +55043,7 @@ fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_whic
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53853,12 +55055,14 @@ fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_whic
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -53932,7 +55136,7 @@ fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_whic
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -53944,12 +55148,14 @@ fn the_root_is_the_atomic_value_false_with_query_select_all_subdocuments_of_whic
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -54023,7 +55229,7 @@ fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_buffered_i
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 5usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 5usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54035,12 +55241,14 @@ fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_buffered_i
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -54114,7 +55322,7 @@ fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_mmap_input
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 5usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 5usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54126,12 +55334,14 @@ fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_mmap_input
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -54205,7 +55415,7 @@ fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_owned_byte
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 5usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 5usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54217,12 +55427,14 @@ fn the_root_is_the_atomic_value_false_with_query_select_the_root_with_owned_byte
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -54296,7 +55508,7 @@ fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54308,12 +55520,14 @@ fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -54387,7 +55601,7 @@ fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54399,12 +55613,14 @@ fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -54478,7 +55694,7 @@ fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54490,12 +55706,14 @@ fn the_root_is_the_atomic_value_null_with_query_select_all_subdocuments_of_which
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -54569,7 +55787,7 @@ fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_buffered_in
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 4usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54581,12 +55799,14 @@ fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_buffered_in
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -54660,7 +55880,7 @@ fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_mmap_input_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 4usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54672,12 +55892,14 @@ fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_mmap_input_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -54751,7 +55973,7 @@ fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_owned_bytes
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 4usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54763,12 +55985,14 @@ fn the_root_is_the_atomic_value_null_with_query_select_the_root_with_owned_bytes
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -54842,7 +56066,7 @@ fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54854,12 +56078,14 @@ fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -54933,7 +56159,7 @@ fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -54945,12 +56171,14 @@ fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -55024,7 +56252,7 @@ fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -55036,12 +56264,14 @@ fn the_root_is_the_atomic_value_true_with_query_select_all_subdocuments_of_which
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -55115,7 +56345,7 @@ fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_buffered_in
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 4usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -55127,12 +56357,14 @@ fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_buffered_in
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -55206,7 +56438,7 @@ fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_mmap_input_
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 4usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -55218,12 +56450,14 @@ fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_mmap_input_
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -55297,7 +56531,7 @@ fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_owned_bytes
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 4usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 4usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -55309,12 +56543,14 @@ fn the_root_is_the_atomic_value_true_with_query_select_the_root_with_owned_bytes
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -58490,7 +59726,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(5usize, 12usize, 12usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(5usize, 12usize, Some(12usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -58502,12 +59738,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -58581,7 +59819,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(5usize, 12usize, 12usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(5usize, 12usize, Some(12usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -58593,12 +59831,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -58672,7 +59912,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(5usize, 12usize, 12usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(5usize, 12usize, Some(12usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -58684,12 +59924,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -58763,7 +60005,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(5usize, 12usize, 12usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(5usize, 12usize, Some(12usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -58775,12 +60017,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -58854,7 +60098,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(5usize, 12usize, 12usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(5usize, 12usize, Some(12usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -58866,12 +60110,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -58945,7 +60191,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(5usize, 12usize, 12usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(5usize, 12usize, Some(12usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -58957,12 +60203,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -59036,10 +60284,10 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (6usize, 7usize, 7usize),
-        (8usize, 9usize, 9usize),
-        (10usize, 11usize, 11usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (6usize, 7usize, Some(7usize)),
+        (8usize, 9usize, Some(9usize)),
+        (10usize, 11usize, Some(11usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -59052,12 +60300,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -59131,10 +60381,10 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (6usize, 7usize, 7usize),
-        (8usize, 9usize, 9usize),
-        (10usize, 11usize, 11usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (6usize, 7usize, Some(7usize)),
+        (8usize, 9usize, Some(9usize)),
+        (10usize, 11usize, Some(11usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -59147,12 +60397,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -59226,10 +60478,10 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (6usize, 7usize, 7usize),
-        (8usize, 9usize, 9usize),
-        (10usize, 11usize, 11usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (6usize, 7usize, Some(7usize)),
+        (8usize, 9usize, Some(9usize)),
+        (10usize, 11usize, Some(11usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -59242,12 +60494,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -59321,7 +60575,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 13usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -59333,12 +60587,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -59412,7 +60668,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 13usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -59424,12 +60680,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -59503,7 +60761,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 13usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 13usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -59515,12 +60773,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -59594,7 +60854,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(9usize, 24usize, 24usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(9usize, 24usize, Some(24usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -59606,12 +60866,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -59685,7 +60947,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(9usize, 24usize, 24usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(9usize, 24usize, Some(24usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -59697,12 +60959,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -59776,7 +61040,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(9usize, 24usize, 24usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(9usize, 24usize, Some(24usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -59788,12 +61052,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -59867,7 +61133,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(9usize, 24usize, 24usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(9usize, 24usize, Some(24usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -59879,12 +61145,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -59958,7 +61226,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(9usize, 24usize, 24usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(9usize, 24usize, Some(24usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -59970,12 +61238,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -60049,7 +61319,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(9usize, 24usize, 24usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(9usize, 24usize, Some(24usize))];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -60061,12 +61331,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -60140,10 +61412,10 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (10usize, 11usize, 13usize),
-        (16usize, 17usize, 19usize),
-        (22usize, 23usize, 23usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (10usize, 11usize, Some(13usize)),
+        (16usize, 17usize, Some(19usize)),
+        (22usize, 23usize, Some(23usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -60156,12 +61428,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -60235,10 +61509,10 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (10usize, 11usize, 13usize),
-        (16usize, 17usize, 19usize),
-        (22usize, 23usize, 23usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (10usize, 11usize, Some(13usize)),
+        (16usize, 17usize, Some(19usize)),
+        (22usize, 23usize, Some(23usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -60251,12 +61525,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -60330,10 +61606,10 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![
-        (10usize, 11usize, 13usize),
-        (16usize, 17usize, 19usize),
-        (22usize, 23usize, 23usize),
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![
+        (10usize, 11usize, Some(13usize)),
+        (16usize, 17usize, Some(19usize)),
+        (22usize, 23usize, Some(23usize)),
     ];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
@@ -60346,12 +61622,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -60425,7 +61703,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 25usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 25usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -60437,12 +61715,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -60516,7 +61796,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 25usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 25usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -60528,12 +61808,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }
@@ -60607,7 +61889,7 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
     let mut result = vec![];
     engine.approximate_spans(&input, &mut result)?;
     let tups: Vec<(usize, usize)> = result.iter().map(|x| (x.start_idx(), x.end_idx())).collect();
-    let expected: Vec<(usize, usize, usize)> = vec![(0usize, 25usize, 18446744073709551615usize)];
+    let expected: Vec<(usize, usize, Option<usize>)> = vec![(0usize, 25usize, None)];
     assert_eq!(tups.len(), expected.len(), "result.len() != expected.len()");
     for i in 0..tups.len() {
         let upper_bound = expected[i];
@@ -60619,12 +61901,14 @@ fn whitespace_separators_between_structurals_to_test_correctness_of_index_result
             actual.1,
             upper_bound.1
         );
-        assert!(
-            actual.1 <= upper_bound.2,
-            "result end_idx() > expected end_upper_bound ({} > {}",
-            actual.1,
-            upper_bound.2
-        );
+        if let Some(end_upper_bound) = upper_bound.2 {
+            assert!(
+                actual.1 <= end_upper_bound,
+                "result end_idx() > expected end_upper_bound ({} > {}",
+                actual.1,
+                end_upper_bound
+            );
+        }
     }
     Ok(())
 }

--- a/crates/rsonpath-lib/tests/input_implementation_tests.rs
+++ b/crates/rsonpath-lib/tests/input_implementation_tests.rs
@@ -142,7 +142,7 @@ fn assert_padding_is_correct(result: &[u8], original_length: usize) {
     );
 
     let padding_length = result.len() - original_length;
-    let expected_padding: Vec<u8> = iter::repeat(0).take(padding_length).collect();
+    let expected_padding: Vec<u8> = iter::repeat(b' ').take(padding_length).collect();
 
     assert_eq!(&result[original_length..], expected_padding);
 }

--- a/crates/rsonpath-test-codegen/src/gen.rs
+++ b/crates/rsonpath-test-codegen/src/gen.rs
@@ -254,6 +254,10 @@ fn get_available_results(input: &model::InputSource, query: &model::Query) -> Re
                     end += 1
                 }
 
+                if end == b.len() {
+                    end = usize::MAX;
+                }
+
                 model::ResultApproximateSpan {
                     start: span.start,
                     end_lower_bound: span.end,

--- a/crates/rsonpath-test-codegen/src/model.rs
+++ b/crates/rsonpath-test-codegen/src/model.rs
@@ -74,7 +74,7 @@ pub(crate) struct ResultApproximateSpan {
     /// Index of the last byte of the match.
     pub(crate) end_lower_bound: usize,
     /// Index of the first non-whitespace after the match.
-    pub(crate) end_upper_bound: usize,
+    pub(crate) end_upper_bound: Option<usize>,
 }
 
 /// Serialize a [`Document`] to [`String`].
@@ -117,13 +117,23 @@ impl<'de> Deserialize<'de> for ResultSpan {
 
 impl quote::ToTokens for ResultApproximateSpan {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        use proc_macro2::{Punct, Spacing};
+        use proc_macro2::{Punct, Ident, Spacing, Span};
         tokens.append(Punct::new('(', Spacing::Alone));
         self.start.to_tokens(tokens);
         tokens.append(Punct::new(',', Spacing::Alone));
         self.end_lower_bound.to_tokens(tokens);
         tokens.append(Punct::new(',', Spacing::Alone));
-        self.end_upper_bound.to_tokens(tokens);
+        
+        match self.end_upper_bound {
+            Some(x) => {
+                tokens.append(Ident::new("Some", Span::call_site()));
+                tokens.append(Punct::new('(', Spacing::Alone));
+                x.to_tokens(tokens);
+                tokens.append(Punct::new(')', Spacing::Alone));
+            },
+            None => tokens.append(Ident::new("None", Span::call_site())),
+        }
+        
         tokens.append(Punct::new(')', Spacing::Alone));
     }
 }

--- a/rsonpath.code-workspace
+++ b/rsonpath.code-workspace
@@ -35,6 +35,7 @@
 			"memchr",
 			"memmap",
 			"Mmap",
+			"mmaps",
 			"movemask",
 			"nondescendant",
 			"nonescaped",


### PR DESCRIPTION
## Short description

The primary goal is to support the empty query on arbitrary JSON documents to behave as one would expect.

```console
$ rq '$' ./empty_file.json -r count
0
```

```console
$ rq '$'
$      {}          
{}
```

```console
$ rq '$'
$ true
true
```

To facilitate that, we move the empty query special case over to a module and specialize all result modes. Most of them are really simple &ndash; asking for count is just asking if the root exists (count of 1) or not (count of 0) and can be done without looking at most of the input. All of those specializations assume valid input JSONs.

As an apropos fix, internal block padding was changed from null bytes to spaces &ndash; null bytes should not appear in a valid JSON at any point, and whitespace are properly neutral to the engine.

## Issue

Resolves: #160

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.