### PR TITLE
chore(ci): work around breaking MinGW release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,6 +97,7 @@ jobs:
         uses: egor-tensin/setup-mingw@84c781b557efd538dec66bde06988d81cd3138cf # v2.2.0
         with:
           platform: ${{ matrix.needs-mingw }}
+          version: 12.2.0 # https://github.com/egor-tensin/setup-mingw/issues/14
       - name: Add MinGW to PATH
         if: matrix.needs-mingw != '' && steps.cache-restore-mingw.outputs.cache-hit == 'true'
         run: echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw32\bin" >> $env:GITHUB_PATH


### PR DESCRIPTION
## Short description

MinGW 13.1.0 broke stuff in the setup-mingw step. Pinning to 12.2.0 is a temporary workaround. See https://github.com/egor-tensin/setup-mingw/issues/14 for details.


## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.