### PR TITLE
Add nightly and rustfmt to nix-shell workflow

### DIFF
--- a/.github/workflows/nix-shell.yml
+++ b/.github/workflows/nix-shell.yml
@@ -26,5 +26,9 @@ jobs:
       - uses: rrbutani/use-nix-shell-action@59a52b2b9bbfe3cc0e7deb8f9059abe37a439edf # v1.1.0
         with:
           file: shell.nix
+      - name: Add Nightly
+        run: rustup toolchain install nightly-x86_64-unknown-linux-gnu
+      - name: Add Rustup
+        run: rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
       - name: Build
         run: just build

--- a/.github/workflows/nix-shell.yml
+++ b/.github/workflows/nix-shell.yml
@@ -26,7 +26,5 @@ jobs:
       - uses: rrbutani/use-nix-shell-action@59a52b2b9bbfe3cc0e7deb8f9059abe37a439edf # v1.1.0
         with:
           file: shell.nix
-      - name: Add rustfmt
-        run: rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
       - name: Build
         run: just build

--- a/.github/workflows/nix-shell.yml
+++ b/.github/workflows/nix-shell.yml
@@ -26,5 +26,7 @@ jobs:
       - uses: rrbutani/use-nix-shell-action@59a52b2b9bbfe3cc0e7deb8f9059abe37a439edf # v1.1.0
         with:
           file: shell.nix
+      - name: Add rustfmt
+        run: rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
       - name: Build
         run: just build


### PR DESCRIPTION
## Short description
This PR adds 2 setup steps to the nix-shell workflow.  First, nightly is installed, and then rustfmt.

This allows rustfmt to be run in the workflow in subsequent steps.

## Issue
This PR is not associated with an existing issue.

## Checklist
- [-] I ran `just verify` locally and it succeeded.
This PR does not change any project-specific code.

- [x]I have included justification for a minor change.
- [X] No functionality was changed.