### PR TITLE
chore(ci): restore test running (hopefully)

### DIFF
--- a/.github/workflows/test-codegen.yml
+++ b/.github/workflows/test-codegen.yml
@@ -8,7 +8,7 @@ on:
         value: rsonpath-test-documents
       artifact-path:
         description: Path to which the artifact should be extracted.
-        value: crates/rsonpath-test/documents
+        value: crates/rsonpath-test
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test-codegen.yml
+++ b/.github/workflows/test-codegen.yml
@@ -69,5 +69,7 @@ jobs:
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: rsonpath-test-documents
-          path: crates/rsonpath-test/documents
+          path: |
+            crates/rsonpath-test/documents
+            crates/rsonpath-test/tests
           retention-days: 1


### PR DESCRIPTION
Seems our engine tests are not running in CI since some time. Kinda embarassing. Trying to fix the test-codegen flow now...