### PR TITLE
test: add msrv verify as ci check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -358,14 +358,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: true
-      - name: Install Rust toolchain (stable)
-        uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # master
+      - name: cargo install cargo-msrv
+        # You may pin to the exact commit or the version.
+        # uses: baptiste0928/cargo-install@1cd874a5478fdca35d868ccc74640c5aabbb8f1b
+        uses: baptiste0928/cargo-install@v3.0.0
         with:
-          toolchain: stable
-      - name: Override toolchain
-        run: rustup override set stable
-      - name: Install cargo-msrv
-        run: cargo install cargo-msrv
+          # Name of the crate to install
+          crate: cargo-msrv
       - name: Run cargo-msrv verify on rsonpath
         run: cargo msrv --path ./crates/rsonpath verify
       - name: Run cargo-msrv verify on rsonpath-lib

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -346,3 +346,29 @@ jobs:
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: EmbarkStudios/cargo-deny-action@68cd9c5e3e16328a430a37c743167572e3243e7e # v1.5.15
+
+  cargo-msrv:
+    name: Verify MSRV (cargo-msrv)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: true
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # master
+        with:
+          toolchain: stable
+      - name: Override toolchain
+        run: rustup override set stable
+      - name: Install cargo-msrv
+        run: cargo install cargo-msrv
+      - name: Run cargo-msrv verify on rsonpath
+        run: cargo msrv --path ./crates/rsonpath verify
+      - name: Run cargo-msrv verify on rsonpath-lib
+        run: cargo msrv --path ./crates/rsonpath-lib verify
+      - name: Run cargo-msrv verify on rsonpath-syntax
+        run: cargo msrv --path ./crates/rsonpath-syntax verify

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub Release Date](https://img.shields.io/github/release-date/v0ldek/rsonpath?logo=github)](https://github.com/V0ldek/rsonpath/releases)
 [![GitHub last commit](https://img.shields.io/github/last-commit/v0ldek/rsonpath?logo=github)](https://github.com/V0ldek/rsonpath/commits/main)
 
-![MSRV](https://img.shields.io/badge/msrv-v1.70.0-orange?logo=rust "Minimum Supported Rust Version for `rq`")
+![MSRV](https://img.shields.io/badge/msrv-v1.67.1-orange?logo=rust "Minimum Supported Rust Version for `rsonpath-lib`")
 [![License](https://img.shields.io/crates/l/rsonpath)](https://choosealicense.com/licenses/mit/)
 
 Experimental JSONPath engine for querying massive streamed datasets.

--- a/crates/rsonpath-syntax/src/error.rs
+++ b/crates/rsonpath-syntax/src/error.rs
@@ -702,18 +702,6 @@ impl SyntaxErrorKind {
     }
 }
 
-pub(super) trait ErrorStyle {
-    fn empty() -> Self;
-    fn error_prefix<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a;
-    fn error_message<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a;
-    fn error_position_hint<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a;
-    fn error_underline<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a;
-    fn error_underline_message<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a;
-    fn line_numbers<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a;
-    fn note_prefix<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a;
-    fn suggestion<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a;
-}
-
 #[cfg(feature = "color")]
 mod colored {
     use super::{fmt_parse_error, ParseError};
@@ -761,10 +749,8 @@ mod colored {
                 suggestion: suggestion_color,
             }
         }
-    }
 
-    impl super::ErrorStyle for OwoColorsErrorStyle {
-        fn empty() -> Self {
+        pub(crate) fn empty() -> Self {
             let empty_style = owo_colors::Style::new();
             Self {
                 error_prefix: empty_style,
@@ -778,42 +764,42 @@ mod colored {
             }
         }
 
-        fn error_prefix<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        pub(crate) fn error_prefix<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             use owo_colors::OwoColorize;
             target.style(self.error_prefix)
         }
 
-        fn error_message<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        pub(crate) fn error_message<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             use owo_colors::OwoColorize;
             target.style(self.error_message)
         }
 
-        fn error_position_hint<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        pub(crate) fn error_position_hint<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             use owo_colors::OwoColorize;
             target.style(self.error_position_hint)
         }
 
-        fn error_underline<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        pub(crate) fn error_underline<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             use owo_colors::OwoColorize;
             target.style(self.error_underline)
         }
 
-        fn error_underline_message<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        pub(crate) fn error_underline_message<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             use owo_colors::OwoColorize;
             target.style(self.error_underline_message)
         }
 
-        fn line_numbers<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        pub(crate) fn line_numbers<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             use owo_colors::OwoColorize;
             target.style(self.line_numbers)
         }
 
-        fn note_prefix<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        pub(crate) fn note_prefix<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             use owo_colors::OwoColorize;
             target.style(self.note_prefix)
         }
 
-        fn suggestion<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        pub(crate) fn suggestion<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             use owo_colors::OwoColorize;
             target.style(self.suggestion)
         }
@@ -827,40 +813,50 @@ mod plain {
     #[derive(Clone)]
     pub(super) struct PlainErrorStyle;
 
-    impl super::ErrorStyle for PlainErrorStyle {
-        fn empty() -> Self {
+    impl PlainErrorStyle {
+        pub(crate) fn empty() -> Self {
             Self
         }
 
-        fn error_prefix<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        // We want to keep the same function signature as for the colored version, so `&self` must be here.
+        // We could use a trait, but returning `impl trait` in traits would bump MSRV to 1.75.
+        #[allow(clippy::unused_self)]
+        pub(crate) fn error_prefix<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             target
         }
 
-        fn error_message<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        #[allow(clippy::unused_self)]
+        pub(crate) fn error_message<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             target
         }
 
-        fn error_position_hint<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        #[allow(clippy::unused_self)]
+        pub(crate) fn error_position_hint<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             target
         }
 
-        fn error_underline<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        #[allow(clippy::unused_self)]
+        pub(crate) fn error_underline<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             target
         }
 
-        fn error_underline_message<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        #[allow(clippy::unused_self)]
+        pub(crate) fn error_underline_message<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             target
         }
 
-        fn line_numbers<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        #[allow(clippy::unused_self)]
+        pub(crate) fn line_numbers<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             target
         }
 
-        fn note_prefix<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        #[allow(clippy::unused_self)]
+        pub(crate) fn note_prefix<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             target
         }
 
-        fn suggestion<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
+        #[allow(clippy::unused_self)]
+        pub(crate) fn suggestion<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             target
         }
     }

--- a/crates/rsonpath/Cargo.toml
+++ b/crates/rsonpath/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://v0ldek.github.io/rsonpath/"
 build = "build.rs"
 workspace = "../.."
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.74.0"
 
 [[bin]]
 bench = false


### PR DESCRIPTION
## Short description

The MSRV got unknowingly bumped before, with this CI check we will avoid it in the future.

This also fixes a violation of MSRV in rsonpath-syntax unknowingly introduced in #477 

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.